### PR TITLE
feat: add --for flag to install for specific coding assistants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 # Project-specific
 # GitHub Copilot agents (managed in agents/ instead)
 .github/agents/
+
+# Internal docs (research, plans, notes)
+docs/

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ code-minions install --dry-run
 # Overwrite existing files
 code-minions install --force
 
-# List available packages and standards
+# Install for a specific coding assistant
+code-minions install --package developer-mentor --for copilot
+code-minions install --package developer-mentor --for claude
+code-minions install --package developer-mentor --for opencode
+
+# List available packages, standards, and assistants
 code-minions list
 
 # Print version
@@ -83,6 +88,7 @@ code-minions version
 |------|------|---------|-------------|
 | `--package` | string | all | Comma-separated list of packages to install |
 | `--standards` | string | all | Comma-separated list of language standards |
+| `--for` | string | | Target coding assistant (`copilot`, `claude`, `opencode`) |
 | `--target` | string | `.` | Target directory for installation |
 | `--dry-run` | bool | false | Show what would be installed without writing files |
 | `--force` | bool | false | Overwrite existing files |
@@ -102,6 +108,18 @@ packages/
 ├── raise-pull-requests/        # PR preparation, submission, and code review
 └── threat-modelling/           # STRIDE-based threat modelling for repositories and cloud infrastructure
 ```
+
+## Coding Assistants
+
+Use the `--for` flag to install packages into the directories expected by your coding assistant:
+
+| Assistant | `--for` value | Agents placed in | Skills placed in |
+|-----------|--------------|------------------|------------------|
+| GitHub Copilot | `copilot` | `.github/agents/` | `skills/` |
+| Claude Code | `claude` | `.claude/agents/` | `.claude/skills/` |
+| OpenCode | `opencode` | `.opencode/agents/` | `.opencode/skills/` |
+
+Without `--for`, files are installed to generic locations (`agents/`, `skills/`, `standards/`). Standards are always placed in `standards/` regardless of the assistant.
 
 ## Standards
 

--- a/internal/assistant/assistant.go
+++ b/internal/assistant/assistant.go
@@ -1,0 +1,106 @@
+package assistant
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+)
+
+type Config struct {
+	Name        string // Assistant identifier, e.g. "copilot", "claude", "opencode"
+	Description string // Human-readable label, e.g. "GitHub Copilot"
+	AgentDir    string // Where agent .md files go, e.g. ".github/agents"
+	SkillDir    string // Where skill directories go, e.g. "skills"
+	StandardDir string // Where standards go, e.g. "standards"
+}
+
+var configs = map[string]Config{
+	"copilot": {
+		Name:        "copilot",
+		Description: "GitHub Copilot",
+		AgentDir:    ".github/agents",
+		SkillDir:    "skills",
+		StandardDir: "standards",
+	},
+	"claude": {
+		Name:        "claude",
+		Description: "Claude Code",
+		AgentDir:    ".claude/agents",
+		SkillDir:    ".claude/skills",
+		StandardDir: "standards",
+	},
+	"opencode": {
+		Name:        "opencode",
+		Description: "OpenCode",
+		AgentDir:    ".opencode/agents",
+		SkillDir:    ".opencode/skills",
+		StandardDir: "standards",
+	},
+}
+
+func Get(name string) (*Config, error) {
+	cfg, ok := configs[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown assistant %q, valid options: %s", name, strings.Join(List(), ", "))
+	}
+
+	// Return a copy so callers can't accidentally modify the registry
+	return &cfg, nil
+}
+
+func List() []string {
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// NewPathMapper returns a function that remaps file paths from the
+// generic package layout (agents/, skills/, standards/) to the
+// directories this assistant expects.
+//
+// For example, with the Copilot config:
+//
+//	agents/my-agent.md   → .github/agents/my-agent.md
+//	skills/foo/SKILL.md  → skills/foo/SKILL.md  (unchanged — Copilot uses skills/ as-is)
+//
+// With the Claude config:
+//
+//	agents/my-agent.md   → .claude/agents/my-agent.md
+//	skills/foo/SKILL.md  → .claude/skills/foo/SKILL.md
+//
+// Paths that don't match any known prefix pass through unchanged.
+func (c *Config) NewPathMapper() func(string) string {
+	// Build the remap table: source prefix → target directory
+	// Using a slice of pairs so we check prefixes in a defined order
+	type remap struct {
+		from string // prefix to match, e.g. "agents"
+		to   string // replacement directory, e.g. ".github/agents"
+	}
+
+	remaps := []remap{
+		{from: "agents", to: c.AgentDir},
+		{from: "skills", to: c.SkillDir},
+		{from: "standards", to: c.StandardDir},
+	}
+
+	return func(p string) string {
+		for _, r := range remaps {
+			// Check if the path starts with this prefix (e.g. "agents/..." or exactly "agents")
+			if p == r.from || strings.HasPrefix(p, r.from+"/") {
+				// If source and target are the same, no work needed
+				if r.from == r.to {
+					return p
+				}
+				// Strip the old prefix and prepend the new one
+				rest := strings.TrimPrefix(p, r.from)
+				return path.Join(r.to, rest)
+			}
+		}
+		// No matching prefix — pass through unchanged
+		return p
+	}
+}

--- a/internal/assistant/assistant_test.go
+++ b/internal/assistant/assistant_test.go
@@ -1,0 +1,228 @@
+package assistant
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetReturnsCorrectConfig(t *testing.T) {
+	tests := []struct {
+		name        string // Description shown in test output
+		assistant   string // Input to Get()
+		agentDir    string // Expected AgentDir
+		skillDir    string // Expected SkillDir
+		standardDir string // Expected StandardDir
+	}{
+		{
+			name:        "copilot uses .github/agents",
+			assistant:   "copilot",
+			agentDir:    ".github/agents",
+			skillDir:    "skills",
+			standardDir: "standards",
+		},
+		{
+			name:        "claude uses .claude directories",
+			assistant:   "claude",
+			agentDir:    ".claude/agents",
+			skillDir:    ".claude/skills",
+			standardDir: "standards",
+		},
+		{
+			name:        "opencode uses .opencode directories",
+			assistant:   "opencode",
+			agentDir:    ".opencode/agents",
+			skillDir:    ".opencode/skills",
+			standardDir: "standards",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Get(tt.assistant)
+			if err != nil {
+				t.Fatalf("Get(%q) returned unexpected error: %v", tt.assistant, err)
+			}
+
+			// Check each field individually so failures are clear
+			if cfg.Name != tt.assistant {
+				t.Errorf("Name: got %q, want %q", cfg.Name, tt.assistant)
+			}
+			if cfg.AgentDir != tt.agentDir {
+				t.Errorf("AgentDir: got %q, want %q", cfg.AgentDir, tt.agentDir)
+			}
+			if cfg.SkillDir != tt.skillDir {
+				t.Errorf("SkillDir: got %q, want %q", cfg.SkillDir, tt.skillDir)
+			}
+			if cfg.StandardDir != tt.standardDir {
+				t.Errorf("StandardDir: got %q, want %q", cfg.StandardDir, tt.standardDir)
+			}
+		})
+	}
+}
+
+func TestGetUnknownAssistantReturnsError(t *testing.T) {
+	_, err := Get("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown assistant, got nil")
+	}
+
+	// The error message should include the invalid name
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error should mention the invalid name, got: %v", err)
+	}
+
+	// The error message should list valid options so the user knows what to type
+	for _, name := range List() {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error should mention valid option %q, got: %v", name, err)
+		}
+	}
+}
+
+func TestListReturnsAllAssistants(t *testing.T) {
+	names := List()
+
+	// We expect exactly 3 assistants
+	if len(names) != 3 {
+		t.Fatalf("List() returned %d names, want 3", len(names))
+	}
+
+	// Check each expected name is present
+	expected := []string{"claude", "copilot", "opencode"}
+	for i, want := range expected {
+		if names[i] != want {
+			t.Errorf("List()[%d]: got %q, want %q", i, names[i], want)
+		}
+	}
+}
+
+func TestGetReturnsCopy(t *testing.T) {
+	cfg, err := Get("copilot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Mutate the returned config
+	cfg.AgentDir = "modified"
+
+	// Fetch again — should still have the original value
+	cfg2, err := Get("copilot")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg2.AgentDir == "modified" {
+		t.Error("modifying returned Config should not affect the registry")
+	}
+}
+
+// TestNewPathMapperRemapsPaths is a table-driven test that verifies
+// NewPathMapper() correctly translates paths for each assistant.
+//
+// Each row specifies an assistant, an input path, and the expected output.
+// This covers the three content types (agents, skills, standards) plus
+// paths that don't match any prefix (pass-through).
+func TestNewPathMapperRemapsPaths(t *testing.T) {
+	tests := []struct {
+		name      string // Description for test output
+		assistant string // Which assistant's mapper to use
+		input     string // Path coming out of the embedded FS (after prefix strip)
+		expected  string // Where it should end up
+	}{
+		// --- Copilot: agents remap to .github/agents, skills and standards stay ---
+		{
+			name:      "copilot remaps agents",
+			assistant: "copilot",
+			input:     "agents/my-agent.agent.md",
+			expected:  ".github/agents/my-agent.agent.md",
+		},
+		{
+			name:      "copilot keeps skills unchanged",
+			assistant: "copilot",
+			input:     "skills/my-skill/SKILL.md",
+			expected:  "skills/my-skill/SKILL.md",
+		},
+		{
+			name:      "copilot keeps standards unchanged",
+			assistant: "copilot",
+			input:     "standards/languages/go/core.md",
+			expected:  "standards/languages/go/core.md",
+		},
+
+		// --- Claude: agents and skills remap to .claude/, standards stay ---
+		{
+			name:      "claude remaps agents",
+			assistant: "claude",
+			input:     "agents/my-agent.md",
+			expected:  ".claude/agents/my-agent.md",
+		},
+		{
+			name:      "claude remaps skills",
+			assistant: "claude",
+			input:     "skills/my-skill/SKILL.md",
+			expected:  ".claude/skills/my-skill/SKILL.md",
+		},
+		{
+			name:      "claude keeps standards unchanged",
+			assistant: "claude",
+			input:     "standards/languages/python/core.md",
+			expected:  "standards/languages/python/core.md",
+		},
+
+		// --- OpenCode: agents and skills remap to .opencode/, standards stay ---
+		{
+			name:      "opencode remaps agents",
+			assistant: "opencode",
+			input:     "agents/my-agent.md",
+			expected:  ".opencode/agents/my-agent.md",
+		},
+		{
+			name:      "opencode remaps skills",
+			assistant: "opencode",
+			input:     "skills/my-skill/actions/create.md",
+			expected:  ".opencode/skills/my-skill/actions/create.md",
+		},
+		{
+			name:      "opencode keeps standards unchanged",
+			assistant: "opencode",
+			input:     "standards/languages/bash/tooling.md",
+			expected:  "standards/languages/bash/tooling.md",
+		},
+
+		// --- Edge cases ---
+		{
+			name:      "unknown prefix passes through",
+			assistant: "copilot",
+			input:     "docs/README.md",
+			expected:  "docs/README.md",
+		},
+		{
+			name:      "bare agents directory name with no trailing content",
+			assistant: "claude",
+			input:     "agents",
+			expected:  ".claude/agents",
+		},
+		{
+			name:      "nested skills path preserves full structure",
+			assistant: "opencode",
+			input:     "skills/dev-mentor/standards/checklist.md",
+			expected:  ".opencode/skills/dev-mentor/standards/checklist.md",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Get(tt.assistant)
+			if err != nil {
+				t.Fatalf("Get(%q) returned unexpected error: %v", tt.assistant, err)
+			}
+
+			mapper := cfg.NewPathMapper()
+			got := mapper(tt.input)
+
+			if got != tt.expected {
+				t.Errorf("mapper(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/willvelida/code-minions/internal/assistant"
 	"github.com/willvelida/code-minions/internal/installer"
 )
 
@@ -21,6 +22,17 @@ func newInstallCommand(content fs.FS) *cobra.Command {
 			force, _ := cmd.Flags().GetBool("force")
 			packageFlag, _ := cmd.Flags().GetString("package")
 			standardsFlag, _ := cmd.Flags().GetString("standards")
+			forFlag, _ := cmd.Flags().GetString("for")
+
+			// If --for is set, look up the assistant config and build a path mapper
+			var pathMapper func(string) string
+			if forFlag != "" {
+				cfg, err := assistant.Get(forFlag)
+				if err != nil {
+					return err
+				}
+				pathMapper = cfg.NewPathMapper()
+			}
 
 			// Build the list of directories to install
 			dirs, err := buildDirList(content, packageFlag, standardsFlag)
@@ -53,6 +65,7 @@ func newInstallCommand(content fs.FS) *cobra.Command {
 					Force:       force,
 					DryRun:      dryRun,
 					StripPrefix: pkgDir,
+					PathMapper:  pathMapper,
 				}
 				result, err := inst.Install([]string{pkgDir})
 				if err != nil {
@@ -66,10 +79,11 @@ func newInstallCommand(content fs.FS) *cobra.Command {
 			// Install standards
 			if len(standardDirs) > 0 {
 				inst := &installer.Installer{
-					Content: content,
-					Target:  target,
-					Force:   force,
-					DryRun:  dryRun,
+					Content:    content,
+					Target:     target,
+					Force:      force,
+					DryRun:     dryRun,
+					PathMapper: pathMapper,
 				}
 				result, err := inst.Install(standardDirs)
 				if err != nil {
@@ -116,6 +130,7 @@ func newInstallCommand(content fs.FS) *cobra.Command {
 	cmd.Flags().String("target", ".", "Target directory for installation")
 	cmd.Flags().String("package", "", "Comma-separated list of packages to install (omit to install all)")
 	cmd.Flags().String("standards", "", "Comma-separated list of language standards to install")
+	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, opencode)")
 	cmd.Flags().Bool("dry-run", false, "Show what would be installed without writing files")
 	cmd.Flags().Bool("force", false, "Overwrite existing files")
 

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 )
@@ -72,5 +74,124 @@ func testContentFS() fstest.MapFS {
 		"packages/developer-mentor/skills/developer-mentor/SKILL.md": &fstest.MapFile{Data: []byte("# Mentor")},
 		"standards/languages/python/core.md":                         &fstest.MapFile{Data: []byte("# Python")},
 		"standards/languages/typescript/core.md":                     &fstest.MapFile{Data: []byte("# TS")},
+	}
+}
+
+// TestInstallForCopilotRemapsPaths verifies that --for copilot places
+// agent files in .github/agents/ while keeping skills and standards
+// in their default locations.
+func TestInstallForCopilotRemapsPaths(t *testing.T) {
+	target := t.TempDir()
+	content := testContentFS()
+
+	cmd := newInstallCommand(content)
+	cmd.SetArgs([]string{
+		"--package", "git-workflow",
+		"--for", "copilot",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Agent file should be in .github/agents/ (remapped from agents/)
+	copilotAgent := filepath.Join(target, ".github", "agents", "git-workflow.agent.md")
+	if _, err := os.Stat(copilotAgent); os.IsNotExist(err) {
+		t.Errorf("expected agent at Copilot path: %s", copilotAgent)
+	}
+
+	// Skills should stay at skills/ (Copilot uses project-root skills/)
+	skillFile := filepath.Join(target, "skills", "git-workflow", "SKILL.md")
+	if _, err := os.Stat(skillFile); os.IsNotExist(err) {
+		t.Errorf("expected skill at default path: %s", skillFile)
+	}
+
+	// Agent should NOT be at the old agents/ path
+	oldAgent := filepath.Join(target, "agents", "git-workflow.agent.md")
+	if _, err := os.Stat(oldAgent); !os.IsNotExist(err) {
+		t.Errorf("agent should NOT exist at old path: %s", oldAgent)
+	}
+}
+
+// TestInstallForClaudeRemapsPaths verifies that --for claude places
+// agent files in .claude/agents/ and skills in .claude/skills/.
+func TestInstallForClaudeRemapsPaths(t *testing.T) {
+	target := t.TempDir()
+	content := testContentFS()
+
+	cmd := newInstallCommand(content)
+	cmd.SetArgs([]string{
+		"--package", "git-workflow",
+		"--for", "claude",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Agent should be in .claude/agents/
+	claudeAgent := filepath.Join(target, ".claude", "agents", "git-workflow.agent.md")
+	if _, err := os.Stat(claudeAgent); os.IsNotExist(err) {
+		t.Errorf("expected agent at Claude path: %s", claudeAgent)
+	}
+
+	// Skills should be in .claude/skills/
+	claudeSkill := filepath.Join(target, ".claude", "skills", "git-workflow", "SKILL.md")
+	if _, err := os.Stat(claudeSkill); os.IsNotExist(err) {
+		t.Errorf("expected skill at Claude path: %s", claudeSkill)
+	}
+}
+
+// TestInstallForUnknownAssistantReturnsError verifies that --for
+// with an invalid assistant name returns a helpful error.
+func TestInstallForUnknownAssistantReturnsError(t *testing.T) {
+	target := t.TempDir()
+	content := testContentFS()
+
+	cmd := newInstallCommand(content)
+	cmd.SetArgs([]string{
+		"--package", "git-workflow",
+		"--for", "vscode",
+		"--target", target,
+	})
+
+	// Silence Cobra's default error printing so it doesn't clutter test output
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown assistant, got nil")
+	}
+}
+
+// TestInstallWithoutForPreservesBehaviour verifies that omitting
+// --for produces the same output as before (no path remapping).
+func TestInstallWithoutForPreservesBehaviour(t *testing.T) {
+	target := t.TempDir()
+	content := testContentFS()
+
+	cmd := newInstallCommand(content)
+	cmd.SetArgs([]string{
+		"--package", "git-workflow",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Without --for, agent lands in agents/ (the generic location)
+	genericAgent := filepath.Join(target, "agents", "git-workflow.agent.md")
+	if _, err := os.Stat(genericAgent); os.IsNotExist(err) {
+		t.Errorf("expected agent at generic path: %s", genericAgent)
+	}
+
+	// Skills in skills/
+	genericSkill := filepath.Join(target, "skills", "git-workflow", "SKILL.md")
+	if _, err := os.Stat(genericSkill); os.IsNotExist(err) {
+		t.Errorf("expected skill at generic path: %s", genericSkill)
 	}
 }

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
+	"github.com/willvelida/code-minions/internal/assistant"
 )
 
 func newListCommand(content fs.FS) *cobra.Command {
@@ -48,6 +49,16 @@ func newListCommand(content fs.FS) *cobra.Command {
 				if entry.IsDir() {
 					cyan.Printf("  %s\n", entry.Name())
 				}
+			}
+
+			// List assistants (for --for flag)
+			bold.Println("\nAssistants (use with --for)")
+			dim.Println(strings.Repeat("-", 40))
+			for _, name := range assistant.List() {
+				cfg, _ := assistant.Get(name)
+				cyan.Printf("  %-15s", name)
+				dim.Printf("  %s", cfg.Description)
+				fmt.Println()
 			}
 
 			fmt.Println()

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -15,6 +15,7 @@ type Installer struct {
 	Force       bool
 	DryRun      bool
 	StripPrefix string
+	PathMapper  func(path string) string // Optional: transforms output paths (e.g. for assistant-specific layouts)
 }
 
 // Result tracks what happened during installation
@@ -46,6 +47,12 @@ func (i *Installer) Install(dirs []string) (*Result, error) {
 					outputPath = strings.TrimPrefix(outputPath, "/")
 				}
 			}
+
+			// Apply optional path mapping (e.g. agents/ → .github/agents/ for Copilot)
+			if i.PathMapper != nil {
+				outputPath = i.PathMapper(outputPath)
+			}
+
 			targetPath := filepath.Join(i.Target, outputPath)
 
 			// Ensure the resolved path stays within the target directory

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -3,6 +3,7 @@ package installer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -222,6 +223,75 @@ func TestInstallStripPrefixRemovesPackageDir(t *testing.T) {
 	skillPath := filepath.Join(target, "skills", "my-pkg", "SKILL.md")
 	if _, err := os.Stat(skillPath); os.IsNotExist(err) {
 		t.Errorf("expected file to exist: %s", skillPath)
+	}
+}
+
+func TestInstallNilPathMapperPreservesBehaviour(t *testing.T) {
+	target := t.TempDir()
+
+	inst := &Installer{
+		Content:    testFS(),
+		Target:     target,
+		Force:      false,
+		DryRun:     false,
+		PathMapper: nil, // Explicitly nil — should behave exactly like before
+	}
+
+	result, err := inst.Install([]string{"agents"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Copied) != 2 {
+		t.Errorf("copied count: got %d, want 2", len(result.Copied))
+	}
+
+	// Files should land in their original paths (agents/)
+	agentPath := filepath.Join(target, "agents", "my-agent.agent.md")
+	if _, err := os.Stat(agentPath); os.IsNotExist(err) {
+		t.Errorf("expected file to exist at original path: %s", agentPath)
+	}
+}
+
+func TestInstallPathMapperRemapsPaths(t *testing.T) {
+	target := t.TempDir()
+
+	// A PathMapper that moves agents/ to .github/agents/
+	// This simulates what the Copilot assistant config would do
+	mapper := func(path string) string {
+		if strings.HasPrefix(path, "agents/") {
+			return ".github/agents/" + strings.TrimPrefix(path, "agents/")
+		}
+		return path
+	}
+
+	inst := &Installer{
+		Content:    testFS(),
+		Target:     target,
+		Force:      false,
+		DryRun:     false,
+		PathMapper: mapper,
+	}
+
+	result, err := inst.Install([]string{"agents"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Copied) != 2 {
+		t.Errorf("copied count: got %d, want 2", len(result.Copied))
+	}
+
+	// Files should land in the REMAPPED path (.github/agents/), not agents/
+	remappedPath := filepath.Join(target, ".github", "agents", "my-agent.agent.md")
+	if _, err := os.Stat(remappedPath); os.IsNotExist(err) {
+		t.Errorf("expected file at remapped path: %s", remappedPath)
+	}
+
+	// The original agents/ path should NOT exist
+	originalPath := filepath.Join(target, "agents", "my-agent.agent.md")
+	if _, err := os.Stat(originalPath); !os.IsNotExist(err) {
+		t.Errorf("file should NOT exist at original path: %s", originalPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a --for flag to the install command so packages are placed in the directories each coding assistant expects.

### Usage

```bash
code-minions install --package developer-mentor --for copilot
code-minions install --package developer-mentor --for claude
code-minions install --package developer-mentor --for opencode
```

### Directory mappings

| Assistant | Agents | Skills | Standards |
|-----------|--------|--------|-----------|
| GitHub Copilot | `.github/agents/` | `skills/` | `standards/` |
| Claude Code | `.claude/agents/` | `.claude/skills/` | `standards/` |
| OpenCode | `.opencode/agents/` | `.opencode/skills/` | `standards/` |
| *(no flag)* | `agents/` | `skills/` | `standards/` |

Without `--for`, existing behaviour is preserved.

### Changes

- **New package:** `internal/assistant` — models each assistant's file layout (`Config`, `Get()`, `List()`, `NewPathMapper()`)
- **Installer:** Added `PathMapper` field for optional path remapping after prefix stripping
- **Install command:** Reads `--for` flag, looks up assistant config, wires PathMapper into Installer
- **List command:** Shows available assistants in output (`code-minions list`)
- **README:** Documents `--for` flag usage, flags table, and assistant mapping
- **`.gitignore`:** Added `docs/` for internal research documents

### Testing

- 40 tests passing across all packages
- Table-driven tests for assistant configs and path mapping (12 sub-tests)
- End-to-end command tests for `--for copilot`, `--for claude`, `--for unknown`, and no flag
- Backwards compatibility verified — nil PathMapper preserves existing behaviour

Closes #17
Resolves #22, #23, #24