### PR TITLE
fix: use ldflags-injected Version for release binaries

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -7,9 +7,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version is set at build time via ldflags:
+//
+//	-X github.com/willvelida/code-minions/internal/cmd.Version=v1.2.3
+var Version string
+
 var readBuildInfo = debug.ReadBuildInfo
 
 func getVersion() string {
+	// Prefer the version injected by ldflags (GoReleaser builds).
+	if Version != "" {
+		return Version
+	}
+
+	// Fall back to debug.BuildInfo (go install builds).
 	info, ok := readBuildInfo()
 	if !ok {
 		return "dev"

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -8,9 +8,29 @@ import (
 func TestGetVersion(t *testing.T) {
 	tests := []struct {
 		name          string
+		version       string
 		buildInfoFunc func() (*debug.BuildInfo, bool)
 		want          string
 	}{
+		{
+			name:    "returns ldflags version when set",
+			version: "v0.5.0",
+			// BuildInfo is irrelevant when ldflags version is set
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return nil, false
+			},
+			want: "v0.5.0",
+		},
+		{
+			name:    "ldflags version takes precedence over build info",
+			version: "v1.0.0",
+			buildInfoFunc: func() (*debug.BuildInfo, bool) {
+				return &debug.BuildInfo{
+					Main: debug.Module{Version: "v0.9.0"},
+				}, true
+			},
+			want: "v1.0.0",
+		},
 		{
 			name: "returns dev when build info is not available",
 			// Simulates: binary built without module support
@@ -52,10 +72,15 @@ func TestGetVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save the original and restore after the test
-			original := readBuildInfo
+			// Save the originals and restore after the test
+			originalBuildInfo := readBuildInfo
+			originalVersion := Version
 			readBuildInfo = tt.buildInfoFunc
-			t.Cleanup(func() { readBuildInfo = original })
+			Version = tt.version
+			t.Cleanup(func() {
+				readBuildInfo = originalBuildInfo
+				Version = originalVersion
+			})
 
 			got := getVersion()
 			if got != tt.want {


### PR DESCRIPTION
## Summary

Add a package-level `Version` variable in `internal/cmd/version.go` that GoReleaser's ldflags can inject at build time (`-X ...cmd.Version={{.Version}}`).

`getVersion()` now follows this priority chain:

1. **`Version`** (set by GoReleaser via ldflags) — release binaries
2. **`debug.BuildInfo`** — `go install` builds
3. **`"dev"`** — local `go run` / unversioned builds

## Changes

- **`internal/cmd/version.go`** — Added `var Version string` and updated `getVersion()` to prefer it
- **`internal/cmd/version_test.go`** — Added 2 new test cases (ldflags set, ldflags precedence over BuildInfo); updated test runner to save/restore `Version`
- **No changes to `.goreleaser.yml`** — the existing ldflags target already matches

## Testing

All existing and new tests pass:

- `returns ldflags version when set` ✅
- `ldflags version takes precedence over build info` ✅
- `returns dev when build info is not available` ✅
- `returns dev when version is (devel)` ✅
- `returns dev when version is empty` ✅
- `returns module version when set` ✅

Fixes #32