### PR TITLE
chore: add Dependabot for Go module and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       prefix: "chore"
     groups:
       go-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch
@@ -28,6 +30,8 @@ updates:
       prefix: "chore"
     groups:
       actions-minor-patch:
+        patterns:
+          - "*"
         update-types:
           - minor
           - patch


### PR DESCRIPTION
## Summary
Configures Dependabot to automatically open PRs for outdated dependencies.

## Changes
- Add `.github/dependabot.yml` with two package ecosystems:
  - **gomod** — weekly checks for Go module updates
  - **github-actions** — weekly checks for Actions version updates
- Minor/patch updates are grouped per ecosystem to reduce PR noise
- Major version bumps get individual PRs for careful review
- PRs are auto-assigned to @willvelida with the `dependencies` label
- Commit messages use the `chore` prefix

Closes #36