### PR TITLE
docs: add GoDoc comments to exported types and functions (#45)

### DIFF
--- a/internal/assistant/assistant.go
+++ b/internal/assistant/assistant.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// Config describes a coding assistant's directory layout for agents and skills.
 type Config struct {
 	Name        string // Assistant identifier, e.g. "copilot", "claude", "opencode"
 	Description string // Human-readable label, e.g. "GitHub Copilot"
@@ -35,6 +36,8 @@ var configs = map[string]Config{
 	},
 }
 
+// Get returns the configuration for the named assistant, or an error if the
+// name is not recognised.
 func Get(name string) (*Config, error) {
 	cfg, ok := configs[name]
 	if !ok {
@@ -45,6 +48,7 @@ func Get(name string) (*Config, error) {
 	return &cfg, nil
 }
 
+// List returns the sorted names of all registered assistants.
 func List() []string {
 	names := make([]string, 0, len(configs))
 	for name := range configs {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// Installer copies embedded content to a target directory
+// Installer copies embedded package content to a target directory.
 type Installer struct {
 	Content     fs.FS
 	Target      string
@@ -18,13 +18,15 @@ type Installer struct {
 	PathMapper  func(path string) string // Optional: transforms output paths (e.g. for assistant-specific layouts)
 }
 
-// Result tracks what happened during installation
+// Result tracks what happened during an installation.
 type Result struct {
 	Copied  []string
 	Skipped []string
 	Errors  []string
 }
 
+// Install walks the embedded filesystem directories and copies their contents
+// to the target directory. It respects Force, DryRun, and PathMapper settings.
 func (i *Installer) Install(dirs []string) (*Result, error) {
 	result := &Result{}
 

--- a/internal/installer/uninstall.go
+++ b/internal/installer/uninstall.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// UninstallResult tracks what happened during uninstallation
+// UninstallResult tracks what happened during an uninstallation.
 type UninstallResult struct {
 	Removed     []string
 	NotFound    []string


### PR DESCRIPTION
## Summary
Add GoDoc comments to all exported types and functions that were missing them, and fix existing comments to follow Go conventions.

## Changes

### `internal/assistant/assistant.go`
- Add comment to `Config` struct
- Add comment to `Get()` function
- Add comment to `List()` function

### `internal/installer/installer.go`
- Add comment to `Install()` method
- Fix `Installer` and `Result` comments to end with periods

### `internal/installer/uninstall.go`
- Fix `UninstallResult` comment to end with period

## Note
`agentsmd.go` was already well-documented — no changes needed there. All affected types are in `internal/` packages so this improves contributor experience (IDE tooltips, code readability) rather than public API docs.

Closes #45