### PR TITLE
feat: add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ Update overwrites installed files with the latest embedded content. When run wit
 | `--target` | string | `.` | Target directory |
 | `--dry-run` | bool | false | Show what would be updated without writing files |
 
+### Shell Completion
+
+Generate shell completion scripts for tab-completion of commands and flags:
+
+```bash
+# Bash
+source <(code-minions completion bash)
+
+# Zsh
+source <(code-minions completion zsh)
+
+# Fish
+code-minions completion fish | source
+
+# PowerShell
+code-minions completion powershell | Out-String | Invoke-Expression
+```
+
+To load completions automatically in every session, add the appropriate command to your shell profile. Run `code-minions completion --help` for per-shell instructions.
+
 ## Packages
 
 Each package bundles an agent and its corresponding skill into a single installable unit.

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newCompletionCommand returns the parent "completion" command with
+// subcommands for each supported shell.
+func newCompletionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion [shell]",
+		Short: "Generate shell completion scripts",
+		Long: `Generate shell completion scripts for code-minions.
+
+To load completions:
+
+  bash:
+    source <(code-minions completion bash)
+
+    # To load completions for each session, add to your profile:
+    # Linux:
+    echo 'source <(code-minions completion bash)' >> ~/.bashrc
+    # macOS:
+    echo 'source <(code-minions completion bash)' >> ~/.bash_profile
+
+  zsh:
+    # If shell completion is not already enabled, enable it:
+    echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+    # Load completions for each session:
+    echo 'source <(code-minions completion zsh)' >> ~/.zshrc
+
+  fish:
+    code-minions completion fish | source
+
+    # To load completions for each session:
+    code-minions completion fish > ~/.config/fish/completions/code-minions.fish
+
+  PowerShell:
+    code-minions completion powershell | Out-String | Invoke-Expression
+
+    # To load completions for each session, add to your profile:
+    echo 'code-minions completion powershell | Out-String | Invoke-Expression' >> $PROFILE
+`,
+	}
+
+	cmd.AddCommand(newBashCompletionCmd())
+	cmd.AddCommand(newZshCompletionCmd())
+	cmd.AddCommand(newFishCompletionCmd())
+	cmd.AddCommand(newPowershellCompletionCmd())
+
+	return cmd
+}
+
+func newBashCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash",
+		Short: "Generate bash completion script",
+		Long: `Generate the autocompletion script for bash.
+
+To load completions in your current shell session:
+
+  source <(code-minions completion bash)
+
+To load completions for every new session, add to your profile:
+
+  # Linux:
+  echo 'source <(code-minions completion bash)' >> ~/.bashrc
+
+  # macOS:
+  echo 'source <(code-minions completion bash)' >> ~/.bash_profile
+`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenBashCompletionV2(cmd.OutOrStdout(), true)
+		},
+	}
+}
+
+func newZshCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "zsh",
+		Short: "Generate zsh completion script",
+		Long: `Generate the autocompletion script for zsh.
+
+If shell completion is not already enabled in your environment,
+you will need to enable it:
+
+  echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load completions in your current shell session:
+
+  source <(code-minions completion zsh)
+
+To load completions for every new session, add to your profile:
+
+  echo 'source <(code-minions completion zsh)' >> ~/.zshrc
+`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+		},
+	}
+}
+
+func newFishCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fish",
+		Short: "Generate fish completion script",
+		Long: `Generate the autocompletion script for fish.
+
+To load completions in your current shell session:
+
+  code-minions completion fish | source
+
+To load completions for every new session:
+
+  code-minions completion fish > ~/.config/fish/completions/code-minions.fish
+`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
+		},
+	}
+}
+
+func newPowershellCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "powershell",
+		Short: "Generate PowerShell completion script",
+		Long: `Generate the autocompletion script for PowerShell.
+
+To load completions in your current shell session:
+
+  code-minions completion powershell | Out-String | Invoke-Expression
+
+To load completions for every new session, add to your PowerShell profile:
+
+  echo 'code-minions completion powershell | Out-String | Invoke-Expression' >> $PROFILE
+`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Root().GenPowerShellCompletionWithDesc(cmd.OutOrStdout())
+		},
+	}
+}

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestRootCmd builds a minimal root command with the completion subcommand
+// registered, matching the structure in NewRootCommand.
+func newTestRootCmd() *cobra.Command {
+	content := fstest.MapFS{}
+	return NewRootCommand(content)
+}
+
+func TestCompletionBash(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newTestRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"completion", "bash"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "code-minions") {
+		t.Errorf("expected bash output to reference code-minions, got:\n%s", output)
+	}
+}
+
+func TestCompletionZsh(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newTestRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"completion", "zsh"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "#compdef") {
+		t.Errorf("expected zsh output to contain #compdef, got:\n%s", output)
+	}
+}
+
+func TestCompletionFish(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newTestRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"completion", "fish"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "complete") {
+		t.Errorf("expected fish output to contain 'complete', got:\n%s", output)
+	}
+}
+
+func TestCompletionPowershell(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newTestRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"completion", "powershell"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Register-ArgumentCompleter") {
+		t.Errorf("expected PowerShell output to contain Register-ArgumentCompleter, got:\n%s", output)
+	}
+}
+
+func TestCompletionNoArgsShowsHelp(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := newTestRootCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"completion"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "bash") || !strings.Contains(output, "powershell") {
+		t.Errorf("expected help output to list available shells, got:\n%s", output)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,6 +23,7 @@ Available components:
 	cmd.AddCommand(newUpdateCommand(content))
 	cmd.AddCommand(newListCommand(content))
 	cmd.AddCommand(newVersionCommand())
+	cmd.AddCommand(newCompletionCommand())
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
Add a `completion` command with subcommands for bash, zsh, fish, and PowerShell.
Each subcommand generates a shell-specific completion script to stdout.

## Changes
- `internal/cmd/completion.go` — parent command + 4 shell subcommands
- `internal/cmd/completion_test.go` — 5 tests covering each shell and argument validation
- `internal/cmd/root.go` — register `completion` command
- `README.md` — add Shell Completion section under CLI

## Key decisions
- Uses `cmd.OutOrStdout()` instead of `os.Stdout` for testability
- Uses `cobra.NoArgs` to reject unexpected arguments
- Uses `RunE` (not `Run`) so `Gen*` errors propagate to callers

Closes #46