### PR TITLE
feat: add Long descriptions and Examples to install, uninstall, and list commands

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -25,8 +25,9 @@ target directory, organised into agents/ and skills/ directories.
 When --for is specified, files are placed in the assistant-specific
 location (e.g. .github/agents/ for GitHub Copilot, .claude/agents/ for Claude).
 
-An AGENTS.md routing file is created or updated at the root of the
-target to help AI assistants discover installed agents.
+An AGENTS.md routing file is created at the root of the target to help
+AI assistants discover installed agents. If AGENTS.md already exists,
+it is left unchanged.
 
 Existing files are skipped unless --force is used. Use --dry-run to
 preview changes without writing any files.`,

--- a/internal/cmd/list.go
+++ b/internal/cmd/list.go
@@ -23,10 +23,7 @@ description from its SKILL.md manifest.
 Use this command to discover what packages are available before running
 install, or to check which assistants are supported by the --for flag.`,
 		Example: `  # List all available packages and assistants
-  code-minions list
-
-  # Output as JSON (for scripting)
-  code-minions list --json`,
+  code-minions list`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Collect package data
 			type packageEntry struct {

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -19,12 +19,14 @@ func newUninstallCommand(content fs.FS) *cobra.Command {
 		Use:   "uninstall",
 		Short: "Remove installed agents and skills from your repository",
 		Long: `Remove previously installed agent and skill files from your repository.
-Only files that match the built-in package registry are removed — your
-own custom files are not touched.
+Only files at paths derived from the built-in package registry are
+targeted for removal. This may delete locally modified versions of
+those files, but files outside these known paths are not touched.
 
-A confirmation prompt is shown before any files are deleted. Use --yes
-to skip the prompt in CI/scripting environments. Use --dry-run to see
-what would be removed without deleting anything.
+In interactive mode a confirmation prompt is shown before any files are
+deleted. Non-interactive output modes (--json, --quiet) do not prompt
+and require --yes to proceed. Use --dry-run to see what would be
+removed without deleting anything.
 
 The --for flag is required when uninstalling all packages, so that
 files are found in the correct assistant-specific location.`,


### PR DESCRIPTION
## Summary

Adds `Long` and `Example` fields to the `install`, `uninstall`, and `list` Cobra command definitions so that `--help` output provides useful context, examples, and explanation beyond the one-line `Short` description.

## Changes

| File | Change |
|------|--------|
| `internal/cmd/install.go` | Added `Long` and `Example` fields |
| `internal/cmd/uninstall.go` | Added `Long` and `Example` fields |
| `internal/cmd/list.go` | Added `Long` and `Example` fields |

## What users see

Each command now shows a multi-line description and concrete usage examples when running `--help`:

- **install**: Explains what gets installed, directory structure, `--for` path mapping, AGENTS.md creation, and `--force`/`--dry-run` behaviour
- **uninstall**: Explains what gets removed, confirmation prompt, `--yes` bypass, and `--for` requirement
- **list**: Explains what's shown and how to use the output for discovery

Examples focus on command-specific flags only (global flags like `--json`/`--verbose`/`--quiet` are documented on root `--help`).

## Testing

- All existing tests pass (`go test ./... -count=1`)
- `golangci-lint run ./...` reports 0 issues
- Manual verification of all three `--help` outputs

Closes #51
