### PR TITLE
feat: add Cursor as a supported coding assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ code-minions install --force
 # Install for a specific coding assistant
 code-minions install --package developer-mentor --for copilot
 code-minions install --package developer-mentor --for claude
+code-minions install --package developer-mentor --for cursor
 code-minions install --package developer-mentor --for opencode
 
 # List available packages, standards, and assistants
@@ -115,7 +116,7 @@ code-minions install --package git-workflow --quiet
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--package` | string | all | Comma-separated list of packages to install |
-| `--for` | string | | Target coding assistant (`copilot`, `claude`, `opencode`) |
+| `--for` | string | | Target coding assistant (`copilot`, `claude`, `cursor`, `opencode`) |
 | `--target` | string | `.` | Target directory for installation |
 | `--dry-run` | bool | false | Show what would be installed without writing files |
 | `--force` | bool | false | Overwrite existing files |
@@ -148,7 +149,7 @@ The uninstall command prompts for confirmation before removing files. You will a
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--package` | string | all | Comma-separated list of packages to uninstall |
-| `--for` | string | | Target coding assistant (`copilot`, `claude`, `opencode`) — **required** when uninstalling everything |
+| `--for` | string | | Target coding assistant (`copilot`, `claude`, `cursor`, `opencode`) — **required** when uninstalling everything |
 | `--target` | string | `.` | Target directory to uninstall from |
 | `--dry-run` | bool | false | Show what would be removed without deleting files |
 | `--yes` / `-y` | bool | false | Skip confirmation prompt and proceed with removal |
@@ -180,7 +181,7 @@ Update overwrites installed files with the latest embedded content. When run wit
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--package` | string | | Comma-separated list of packages to update (omit to auto-detect installed) |
-| `--for` | string | | Target coding assistant (`copilot`, `claude`, `opencode`) |
+| `--for` | string | | Target coding assistant (`copilot`, `claude`, `cursor`, `opencode`) |
 | `--target` | string | `.` | Target directory |
 | `--dry-run` | bool | false | Show what would be updated without writing files |
 | `--json` | bool | false | Output results as JSON |
@@ -216,8 +217,8 @@ MCP server configurations are automatically translated between the source and ta
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--from` | string | | Source coding assistant (`copilot`, `claude`, `opencode`) — **required** |
-| `--to` | string | | Target coding assistant (`copilot`, `claude`, `opencode`) — **required** |
+| `--from` | string | | Source coding assistant (`copilot`, `claude`, `cursor`, `opencode`) — **required** |
+| `--to` | string | | Target coding assistant (`copilot`, `claude`, `cursor`, `opencode`) — **required** |
 | `--target` | string | `.` | Working directory |
 | `--dry-run` | bool | false | Preview changes without writing files |
 | `--force` | bool | false | Overwrite existing files at the destination |
@@ -310,6 +311,7 @@ Use the `--for` flag to install packages into the directories expected by your c
 |-----------|--------------|------------------|------------------|
 | GitHub Copilot | `copilot` | `.github/agents/` | `skills/` |
 | Claude Code | `claude` | `.claude/agents/` | `.claude/skills/` |
+| Cursor | `cursor` | `.cursor/agents/` | `.cursor/skills/` |
 | OpenCode | `opencode` | `.opencode/agents/` | `.opencode/skills/` |
 
 Without `--for`, files are installed to generic locations (`agents/`, `skills/`).

--- a/internal/assistant/assistant.go
+++ b/internal/assistant/assistant.go
@@ -47,6 +47,15 @@ var configs = map[string]Config{
 		MCPConfigKey:     "mcp",
 		InstructionsPath: ".opencode/instructions.md",
 	},
+	"cursor": {
+		Name:             "cursor",
+		Description:      "Cursor",
+		AgentDir:         ".cursor/agents",
+		SkillDir:         ".cursor/skills",
+		MCPConfigPath:    ".cursor/mcp.json",
+		MCPConfigKey:     "mcpServers",
+		InstructionsPath: ".cursor/rules/instructions.mdc",
+	},
 }
 
 // Get returns the configuration for the named assistant, or an error if the

--- a/internal/assistant/assistant_test.go
+++ b/internal/assistant/assistant_test.go
@@ -38,6 +38,14 @@ func TestGetReturnsCorrectConfig(t *testing.T) {
 			mcpConfigPath: "opencode.json",
 			mcpConfigKey:  "mcp",
 		},
+		{
+			name:          "cursor uses .cursor directories",
+			assistant:     "cursor",
+			agentDir:      ".cursor/agents",
+			skillDir:      ".cursor/skills",
+			mcpConfigPath: ".cursor/mcp.json",
+			mcpConfigKey:  "mcpServers",
+		},
 	}
 
 	for _, tt := range tests {
@@ -89,13 +97,13 @@ func TestGetUnknownAssistantReturnsError(t *testing.T) {
 func TestListReturnsAllAssistants(t *testing.T) {
 	names := List()
 
-	// We expect exactly 3 assistants
-	if len(names) != 3 {
-		t.Fatalf("List() returned %d names, want 3", len(names))
+	// We expect exactly 4 assistants
+	if len(names) != 4 {
+		t.Fatalf("List() returned %d names, want 4", len(names))
 	}
 
 	// Check each expected name is present
-	expected := []string{"claude", "copilot", "opencode"}
+	expected := []string{"claude", "copilot", "cursor", "opencode"}
 	for i, want := range expected {
 		if names[i] != want {
 			t.Errorf("List()[%d]: got %q, want %q", i, names[i], want)
@@ -176,6 +184,20 @@ func TestNewPathMapperRemapsPaths(t *testing.T) {
 			assistant: "opencode",
 			input:     "skills/my-skill/actions/create.md",
 			expected:  ".opencode/skills/my-skill/actions/create.md",
+		},
+
+		// --- Cursor: agents and skills remap to .cursor/ ---
+		{
+			name:      "cursor remaps agents",
+			assistant: "cursor",
+			input:     "agents/my-agent.md",
+			expected:  ".cursor/agents/my-agent.md",
+		},
+		{
+			name:      "cursor remaps skills",
+			assistant: "cursor",
+			input:     "skills/my-skill/SKILL.md",
+			expected:  ".cursor/skills/my-skill/SKILL.md",
 		},
 
 		// --- Edge cases ---
@@ -264,6 +286,20 @@ func TestNewReversePathMapperRemapsPaths(t *testing.T) {
 			name:      "opencode reverses skills",
 			assistant: "opencode",
 			input:     ".opencode/skills/bar/SKILL.md",
+			expected:  "skills/bar/SKILL.md",
+		},
+
+		// --- Cursor: .cursor/agents → agents, .cursor/skills → skills ---
+		{
+			name:      "cursor reverses agents",
+			assistant: "cursor",
+			input:     ".cursor/agents/foo.md",
+			expected:  "agents/foo.md",
+		},
+		{
+			name:      "cursor reverses skills",
+			assistant: "cursor",
+			input:     ".cursor/skills/bar/SKILL.md",
 			expected:  "skills/bar/SKILL.md",
 		},
 

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -375,7 +375,7 @@ preview changes without writing any files.`,
 	cmd.Flags().String("target", ".", "Target directory for installation")
 	cmd.Flags().String("package", "", "Comma-separated list of packages to install (omit to install all)")
 	cmd.Flags().String("persona", "", "Install a persona (a named bundle of packages)")
-	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, opencode)")
+	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, cursor, opencode)")
 	cmd.Flags().Bool("dry-run", false, "Show what would be installed without writing files")
 	cmd.Flags().Bool("force", false, "Overwrite existing files")
 

--- a/internal/cmd/json_test.go
+++ b/internal/cmd/json_test.go
@@ -100,7 +100,7 @@ func TestListJSON(t *testing.T) {
 	for _, a := range result.Assistants {
 		aNames[a.Name] = true
 	}
-	for _, want := range []string{"copilot", "claude", "opencode"} {
+	for _, want := range []string{"copilot", "claude", "cursor", "opencode"} {
 		if !aNames[want] {
 			t.Errorf("expected assistant %q in output", want)
 		}

--- a/internal/cmd/list_test.go
+++ b/internal/cmd/list_test.go
@@ -105,9 +105,11 @@ func TestListCommandOutputContainsAssistants(t *testing.T) {
 		"Assistants",
 		"copilot",
 		"claude",
+		"cursor",
 		"opencode",
 		"GitHub Copilot",
 		"Claude Code",
+		"Cursor",
 		"OpenCode",
 	}
 	for _, want := range expected {

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -9,7 +9,7 @@ func newMCPCommand() *cobra.Command {
 		Use:   "mcp",
 		Short: "Manage MCP server configurations across coding assistants",
 		Long: `Translate and inspect MCP (Model Context Protocol) server configurations
-between coding assistants such as GitHub Copilot, Claude Code, and OpenCode.
+between coding assistants such as GitHub Copilot, Claude Code, Cursor, and OpenCode.
 
 Sub-commands allow you to translate server configs from one assistant's format
 to another, or list the MCP servers currently configured for a specific assistant.`,

--- a/internal/cmd/transfer.go
+++ b/internal/cmd/transfer.go
@@ -141,8 +141,8 @@ layout because it contains assistant-specific paths.`,
 		},
 	}
 
-	cmd.Flags().String("from", "", "Source coding assistant (copilot, claude, opencode)")
-	cmd.Flags().String("to", "", "Target coding assistant (copilot, claude, opencode)")
+	cmd.Flags().String("from", "", "Source coding assistant (copilot, claude, cursor, opencode)")
+	cmd.Flags().String("to", "", "Target coding assistant (copilot, claude, cursor, opencode)")
 	cmd.Flags().String("target", ".", "Target directory")
 	cmd.Flags().Bool("dry-run", false, "Preview changes without writing files")
 	cmd.Flags().Bool("force", false, "Overwrite existing files at the destination")

--- a/internal/cmd/uninstall.go
+++ b/internal/cmd/uninstall.go
@@ -410,7 +410,7 @@ files are found in the correct assistant-specific location.`,
 	cmd.Flags().String("target", ".", "Target directory to uninstall from")
 	cmd.Flags().String("package", "", "Comma-separated list of packages to uninstall (omit to uninstall all)")
 	cmd.Flags().String("persona", "", "Uninstall a persona (a named bundle of packages)")
-	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, opencode)")
+	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, cursor, opencode)")
 	cmd.Flags().Bool("dry-run", false, "Show what would be removed without deleting files")
 	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt and proceed with removal")
 

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -229,7 +229,7 @@ AGENTS.md is not modified during updates.`,
 	cmd.Flags().String("target", ".", "Target directory for update")
 	cmd.Flags().String("package", "", "Comma-separated list of packages to update (omit to auto-detect installed packages)")
 	cmd.Flags().String("persona", "", "Update a persona (re-install all its packages with latest content)")
-	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, opencode)")
+	cmd.Flags().String("for", "", "Target coding assistant (copilot, claude, cursor, opencode)")
 	cmd.Flags().Bool("dry-run", false, "Show what would be updated without writing files")
 
 	return cmd

--- a/internal/installer/cursor_persona.go
+++ b/internal/installer/cursor_persona.go
@@ -1,0 +1,107 @@
+package installer
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/willvelida/code-minions/internal/assistant"
+	"github.com/willvelida/code-minions/internal/registry"
+)
+
+// CursorGrouping generates a persona agent file for Cursor.
+//
+// Cursor discovers agents from .cursor/agents/ (Markdown files with
+// YAML frontmatter). It also reads skills from .cursor/skills/.
+//
+// Cursor's agent discovery model is similar to Claude Code — agents
+// are Markdown files with YAML frontmatter describing the agent's
+// purpose and capabilities. MCP server references use the mcpServers:
+// key in the frontmatter, matching Cursor's MCP config format.
+//
+// Generated file: .cursor/agents/<persona-name>.agent.md
+type CursorGrouping struct {
+	Config     *assistant.Config
+	Resolved   *registry.ResolvedPersona
+	Target     string
+	DryRun     bool
+	Force      bool
+	MCPServers []string // MCP server names (set via SetMCPServers)
+}
+
+// SetMCPServers provides MCP server names for frontmatter generation.
+// Cursor uses mcpServers: in YAML frontmatter — each entry is a
+// server name referencing an already-configured server in
+// .cursor/mcp.json.
+func (g *CursorGrouping) SetMCPServers(servers []string) {
+	g.MCPServers = servers
+}
+
+// Generate creates the persona agent file at
+// .cursor/agents/<persona-name>.agent.md
+func (g *CursorGrouping) Generate() ([]string, error) {
+	persona := g.Resolved.Persona
+
+	content := g.buildAgentContent()
+
+	// For Cursor: .cursor/agents/senior-dev.agent.md
+	outputPath := path.Join(g.Config.AgentDir, persona.Name+".agent.md")
+
+	err := writeGeneratedFile(g.Target, outputPath, []byte(content), g.DryRun, g.Force)
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{outputPath}, nil
+}
+
+// buildAgentContent generates the full Markdown content for the
+// persona agent, including YAML frontmatter.
+func (g *CursorGrouping) buildAgentContent() string {
+	persona := g.Resolved.Persona
+
+	var sb strings.Builder
+
+	// YAML frontmatter — Cursor reads this to discover and
+	// describe the agent.
+	sb.WriteString("---\n")
+	fmt.Fprintf(&sb, "description: %s\n", escapeYAMLValue(persona.Description))
+
+	// MCP server references — tells Cursor which MCP servers
+	// this persona can use. Each entry references a server name
+	// already configured in .cursor/mcp.json.
+	if len(g.MCPServers) > 0 {
+		sb.WriteString("mcpServers:\n")
+		for _, server := range g.MCPServers {
+			fmt.Fprintf(&sb, "  - %s\n", server)
+		}
+	}
+
+	sb.WriteString("---\n\n")
+
+	// Agent title
+	fmt.Fprintf(&sb, "# %s\n\n", persona.Name)
+
+	// Body text — describes the persona's capabilities
+	fmt.Fprintf(&sb, "You are operating as the **%s** persona. You have the following capabilities:\n\n", persona.Name)
+
+	// List each package as a capability
+	for _, rp := range g.Resolved.Packages {
+		name := rp.Package.Name
+		desc := rp.Package.Description
+		if desc == "" {
+			desc = "No description"
+		}
+		displayName := toTitleCase(name)
+		fmt.Fprintf(&sb, "- **%s** — %s\n", displayName, desc)
+	}
+
+	// Persona-level instructions
+	if persona.Instructions != "" {
+		sb.WriteString("\n")
+		sb.WriteString(strings.TrimSpace(persona.Instructions))
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}

--- a/internal/installer/grouping.go
+++ b/internal/installer/grouping.go
@@ -68,6 +68,14 @@ func NewGroupingGenerator(
 			DryRun:   dryRun,
 			Force:    force,
 		}, nil
+	case "cursor":
+		return &CursorGrouping{
+			Config:   cfg,
+			Resolved: resolved,
+			Target:   target,
+			DryRun:   dryRun,
+			Force:    force,
+		}, nil
 	default:
 		// For assistants we don't have a specific generator for,
 		// return a no-op generator that doesn't create any files.

--- a/internal/installer/persona_test.go
+++ b/internal/installer/persona_test.go
@@ -276,6 +276,67 @@ func TestPersonaInstallerInstallOpenCode(t *testing.T) {
 	}
 }
 
+func TestPersonaInstallerInstallCursor(t *testing.T) {
+	// This test verifies that installing a persona for Cursor:
+	// 1. Copies files to .cursor/agents/ and .cursor/skills/
+	// 2. Generates a persona agent at .cursor/agents/senior-dev.agent.md
+	resolved, _ := testResolvedPersona(t)
+	target := t.TempDir()
+
+	pi := &PersonaInstaller{
+		Resolved:      resolved,
+		AssistantName: "cursor",
+		Target:        target,
+		Force:         false,
+		DryRun:        false,
+	}
+
+	result, err := pi.Install()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify Cursor-specific file locations
+	expectedFiles := []string{
+		".cursor/agents/git-workflow.agent.md",
+		".cursor/skills/git-workflow/SKILL.md",
+		".cursor/agents/threat-modelling.agent.md",
+		".cursor/skills/threat-modelling/SKILL.md",
+	}
+
+	for _, f := range expectedFiles {
+		fullPath := filepath.Join(target, f)
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			t.Errorf("expected file to exist: %s", f)
+		}
+	}
+
+	// Verify persona agent was generated
+	personaAgentPath := filepath.Join(target, ".cursor/agents/senior-dev.agent.md")
+	data, err := os.ReadFile(personaAgentPath)
+	if err != nil {
+		t.Fatalf("failed to read persona agent: %v", err)
+	}
+
+	content := string(data)
+
+	// Check frontmatter
+	if !strings.Contains(content, "description:") {
+		t.Error("persona agent missing frontmatter description")
+	}
+	// Check body
+	if !strings.Contains(content, "senior-dev") {
+		t.Error("persona agent missing persona name in body")
+	}
+	if !strings.Contains(content, "Git Workflow") {
+		t.Error("persona agent missing package reference")
+	}
+
+	if result.TotalErrors() > 0 {
+		t.Errorf("expected 0 errors, got %d", result.TotalErrors())
+	}
+}
+
 func TestPersonaInstallerDryRun(t *testing.T) {
 	// Dry run should NOT create any files on disk,
 	// but should still report what WOULD be created.
@@ -754,6 +815,12 @@ func TestPersonaGroupingIncludesMCPServers(t *testing.T) {
 			wantFile:  ".opencode/agents/pr-dev.md",
 			wantMCP:   []string{"github_*: true", "linear_*: true"},
 		},
+		{
+			name:      "cursor includes MCP servers",
+			assistant: "cursor",
+			wantFile:  ".cursor/agents/pr-dev.agent.md",
+			wantMCP:   []string{"mcpServers:", "github", "linear"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -904,6 +971,19 @@ func TestNewGroupingGeneratorOpenCode(t *testing.T) {
 	}
 	if _, ok := gen.(*OpenCodeGrouping); !ok {
 		t.Errorf("expected *OpenCodeGrouping, got %T", gen)
+	}
+}
+
+func TestNewGroupingGeneratorCursor(t *testing.T) {
+	cfg, _ := assistant.Get("cursor")
+	resolved, _ := testResolvedPersona(t)
+
+	gen, err := NewGroupingGenerator(cfg, resolved, t.TempDir(), false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := gen.(*CursorGrouping); !ok {
+		t.Errorf("expected *CursorGrouping, got %T", gen)
 	}
 }
 

--- a/internal/mcp/cursor.go
+++ b/internal/mcp/cursor.go
@@ -1,0 +1,106 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CursorTranslator converts canonical MCP config to Cursor's
+// .cursor/mcp.json format.
+//
+// Cursor format (under "mcpServers" key):
+//
+//	{
+//	  "mcpServers": {
+//	    "github": {
+//	      "command": "npx",
+//	      "args": ["-y", "@modelcontextprotocol/server-github"],
+//	      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "" }
+//	    }
+//	  }
+//	}
+//
+// Cursor uses the same JSON schema as Claude Code for MCP servers
+// (mcpServers key, command/args/env for stdio, url for HTTP) but
+// stores the config in .cursor/mcp.json instead of
+// .claude/settings.local.json.
+type CursorTranslator struct{}
+
+func (c *CursorTranslator) ConfigPath() string { return ".cursor/mcp.json" }
+func (c *CursorTranslator) ConfigKey() string  { return "mcpServers" }
+
+func (c *CursorTranslator) Translate(cfg *Config) (map[string]any, []string, error) {
+	servers := make(map[string]any)
+	var warnings []string
+
+	for name, s := range cfg.Servers {
+		switch s.Transport {
+		case TransportStdio:
+			entry := map[string]any{
+				"command": s.Command,
+			}
+			if len(s.Args) > 0 {
+				entry["args"] = s.Args
+			}
+			if len(s.Env) > 0 {
+				entry["env"] = s.Env
+			}
+			servers[name] = entry
+
+		case TransportSSE, TransportStreamableHTTP:
+			// Cursor supports HTTP-based MCP servers via url
+			entry := map[string]any{
+				"url": s.URL,
+			}
+			if len(s.Headers) > 0 {
+				entry["headers"] = s.Headers
+			}
+			if len(s.Env) > 0 {
+				entry["env"] = s.Env
+			}
+			servers[name] = entry
+
+		default:
+			warnings = append(warnings, fmt.Sprintf("server %q: unsupported transport %q for Cursor", name, s.Transport))
+		}
+	}
+
+	return servers, warnings, nil
+}
+
+// CursorReader parses Cursor's .cursor/mcp.json format.
+//
+// Cursor format:
+//
+//	{
+//	  "mcpServers": {
+//	    "github": {
+//	      "command": "npx",
+//	      "args": ["-y", "@modelcontextprotocol/server-github"],
+//	      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "" }
+//	    }
+//	  }
+//	}
+type CursorReader struct{}
+
+func (r *CursorReader) ConfigPath() string { return ".cursor/mcp.json" }
+func (r *CursorReader) ConfigKey() string  { return "mcpServers" }
+
+func (r *CursorReader) Read(data []byte) (*Config, []string, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse Cursor MCP config: %w", err)
+	}
+
+	raw, ok := doc["mcpServers"]
+	if !ok {
+		return &Config{Servers: map[string]Server{}}, nil, nil
+	}
+
+	var servers map[string]map[string]any
+	if err := json.Unmarshal(raw, &servers); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse Cursor mcpServers: %w", err)
+	}
+
+	return readStandardFormat(servers, "Cursor")
+}

--- a/internal/mcp/reader.go
+++ b/internal/mcp/reader.go
@@ -34,6 +34,8 @@ func NewReader(assistant string) (Reader, error) {
 		return &ClaudeReader{}, nil
 	case "opencode":
 		return &OpenCodeReader{}, nil
+	case "cursor":
+		return &CursorReader{}, nil
 	default:
 		return nil, fmt.Errorf("no MCP reader for assistant %q", assistant)
 	}

--- a/internal/mcp/reader_test.go
+++ b/internal/mcp/reader_test.go
@@ -513,6 +513,87 @@ func TestOpenCodeReader_RemoteMissingURL(t *testing.T) {
 	}
 }
 
+// --- Cursor Reader ---
+
+func TestCursorReader_StdioServer(t *testing.T) {
+	input := `{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "" }
+    }
+  }
+}`
+	r := &CursorReader{}
+	cfg, _, err := r.Read([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := cfg.Servers["github"]
+	if s.Transport != TransportStdio {
+		t.Errorf("transport: got %q, want %q", s.Transport, TransportStdio)
+	}
+	if s.Command != "npx" {
+		t.Errorf("command: got %q, want %q", s.Command, "npx")
+	}
+	if len(s.Args) != 2 {
+		t.Errorf("args: got %v", s.Args)
+	}
+}
+
+func TestCursorReader_HTTPServer(t *testing.T) {
+	input := `{
+  "mcpServers": {
+    "api": {
+      "url": "https://mcp.example.com/v1",
+      "headers": { "Authorization": "Bearer token" },
+      "env": { "API_KEY": "secret" }
+    }
+  }
+}`
+	r := &CursorReader{}
+	cfg, _, err := r.Read([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	s := cfg.Servers["api"]
+	if s.Transport != TransportSSE {
+		t.Errorf("transport: got %q, want %q", s.Transport, TransportSSE)
+	}
+	if s.URL != "https://mcp.example.com/v1" {
+		t.Errorf("url: got %q", s.URL)
+	}
+	if s.Headers["Authorization"] != "Bearer token" {
+		t.Errorf("headers: got %v", s.Headers)
+	}
+	if s.Env["API_KEY"] != "secret" {
+		t.Errorf("env: got %v", s.Env)
+	}
+}
+
+func TestCursorReader_NoMCPServersKey(t *testing.T) {
+	input := `{ "settings": {} }`
+	r := &CursorReader{}
+	cfg, _, err := r.Read([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(cfg.Servers))
+	}
+}
+
+func TestCursorReader_MalformedJSON(t *testing.T) {
+	r := &CursorReader{}
+	_, _, err := r.Read([]byte("{bad"))
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
 // --- NewReader factory ---
 
 func TestNewReader_ValidAssistants(t *testing.T) {
@@ -523,6 +604,7 @@ func TestNewReader_ValidAssistants(t *testing.T) {
 		{"copilot", ".vscode/mcp.json"},
 		{"claude", ".claude/settings.local.json"},
 		{"opencode", "opencode.json"},
+		{"cursor", ".cursor/mcp.json"},
 	}
 
 	for _, tt := range tests {
@@ -638,6 +720,38 @@ func TestRoundTrip_OpenCodeReadWrite(t *testing.T) {
 	}
 
 	translated, _ := json.Marshal(map[string]any{"mcp": servers})
+	cfg2, _, err := reader.Read(translated)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+
+	assertConfigsEqual(t, cfg, cfg2)
+}
+
+// TestRoundTrip_CursorReadWrite reads Cursor config and round-trips it.
+func TestRoundTrip_CursorReadWrite(t *testing.T) {
+	input := `{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "" }
+    }
+  }
+}`
+	reader := &CursorReader{}
+	cfg, _, err := reader.Read([]byte(input))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	writer := &CursorTranslator{}
+	servers, _, err := writer.Translate(cfg)
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+
+	translated, _ := json.Marshal(map[string]any{"mcpServers": servers})
 	cfg2, _, err := reader.Read(translated)
 	if err != nil {
 		t.Fatalf("re-read: %v", err)

--- a/internal/mcp/translator.go
+++ b/internal/mcp/translator.go
@@ -33,6 +33,8 @@ func NewTranslator(assistant string) (Translator, error) {
 		return &ClaudeTranslator{}, nil
 	case "opencode":
 		return &OpenCodeTranslator{}, nil
+	case "cursor":
+		return &CursorTranslator{}, nil
 	default:
 		return nil, fmt.Errorf("no MCP translator for assistant %q", assistant)
 	}

--- a/internal/mcp/translator_test.go
+++ b/internal/mcp/translator_test.go
@@ -349,6 +349,65 @@ func TestOpenCodeTranslator_ConfigPath(t *testing.T) {
 	}
 }
 
+// --- Cursor ---
+
+func TestCursorTranslator_Stdio(t *testing.T) {
+	tr := &CursorTranslator{}
+	servers, warnings, err := tr.Translate(testStdioConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+
+	github := servers["github"].(map[string]any)
+	if github["command"] != "npx" {
+		t.Errorf("command: got %v", github["command"])
+	}
+}
+
+func TestCursorTranslator_HTTP(t *testing.T) {
+	tr := &CursorTranslator{}
+	servers, _, err := tr.Translate(testHTTPConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	api := servers["remote-api"].(map[string]any)
+	if api["url"] != "https://mcp.example.com/v1" {
+		t.Errorf("url: got %v", api["url"])
+	}
+}
+
+func TestCursorTranslator_SSE(t *testing.T) {
+	tr := &CursorTranslator{}
+	servers, _, err := tr.Translate(testSSEConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	api := servers["sse-api"].(map[string]any)
+	if api["url"] != "https://sse.example.com/events" {
+		t.Errorf("url: got %v", api["url"])
+	}
+	// Cursor should include env for SSE
+	env := api["env"].(map[string]string)
+	if env["API_KEY"] != "secret" {
+		t.Errorf("env: got %v", env)
+	}
+}
+
+func TestCursorTranslator_ConfigPath(t *testing.T) {
+	tr := &CursorTranslator{}
+	if tr.ConfigPath() != ".cursor/mcp.json" {
+		t.Errorf("ConfigPath: got %q", tr.ConfigPath())
+	}
+	if tr.ConfigKey() != "mcpServers" {
+		t.Errorf("ConfigKey: got %q", tr.ConfigKey())
+	}
+}
+
 // --- Factory ---
 
 func TestNewTranslator(t *testing.T) {
@@ -359,6 +418,7 @@ func TestNewTranslator(t *testing.T) {
 		{"copilot", false},
 		{"claude", false},
 		{"opencode", false},
+		{"cursor", false},
 		{"unknown", true},
 	}
 
@@ -385,7 +445,7 @@ func TestNewTranslator(t *testing.T) {
 // ConfigPath() and ConfigKey() return the same values as the corresponding
 // assistant.Config. This prevents drift between the two sources.
 func TestTranslatorConfigMatchesAssistant(t *testing.T) {
-	names := []string{"copilot", "claude", "opencode"}
+	names := []string{"copilot", "claude", "opencode", "cursor"}
 	for _, name := range names {
 		t.Run(name, func(t *testing.T) {
 			tr, err := NewTranslator(name)


### PR DESCRIPTION
## Summary
Closes #88

Adds Cursor as a fourth supported coding assistant alongside GitHub Copilot, Claude Code, and OpenCode.

## Changes

### Assistant Config
- Added `cursor` entry to the assistant config registry (`internal/assistant/assistant.go`)
- Config: agent dir `.cursor/agents/`, skill dir `.cursor/skills/`, MCP config `.cursor/mcp.json`, instructions `.cursor/rules/instructions.mdc`

### MCP Translator & Reader
- New `CursorTranslator` and `CursorReader` in `internal/mcp/cursor.go`
- Supports stdio, SSE, and StreamableHTTP server types
- Uses `mcpServers` key (same schema as Claude Code)
- Updated factories in `reader.go` and `translator.go`

### Persona Grouping
- New `CursorGrouping` in `internal/installer/cursor_persona.go`
- Generates `.cursor/agents/<name>.agent.md` with YAML frontmatter
- Updated factory in `grouping.go`

### CLI Flag Descriptions
- Updated `--for`/`--from`/`--to` flag help text in install, uninstall, update, transfer, and mcp commands

### Documentation
- Updated README assistants table and all `--for` flag references

## Testing
- All existing tests pass
- Added tests for: assistant config, MCP translator (stdio/HTTP/SSE/ConfigPath), MCP reader (stdio/HTTP/no-key/malformed/round-trip), persona installer, grouping factory, list command output, JSON output
- Coverage: 88.0% (threshold: 70%)