### PR TITLE
feat: fetch remote packages from GitHub repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ code-minions install --package developer-mentor --for cursor
 code-minions install --package developer-mentor --for gemini
 code-minions install --package developer-mentor --for opencode
 
+# Install from an external package source (Git URL)
+code-minions install --package my-skill --from github.com/org/packages
+
+# Install from a configured named source
+code-minions install --package my-skill --from my-team
+
 # List available packages, standards, and assistants
 code-minions list
 
@@ -139,6 +145,7 @@ code-minions install --package git-workflow --quiet
 |------|------|---------|-------------|
 | `--package` | string | all | Comma-separated list of packages to install |
 | `--for` | string | | Target coding assistant (`claude`, `codex`, `copilot`, `cursor`, `gemini`, `opencode`) |
+| `--from` | string | | Install from a specific source (configured name or Git URL) |
 | `--target` | string | `.` | Target directory for installation |
 | `--dry-run` | bool | false | Show what would be installed without writing files |
 | `--force` | bool | false | Overwrite existing files |
@@ -149,6 +156,42 @@ code-minions install --package git-workflow --quiet
 When installing packages, an `AGENTS.md` file is automatically created if one does not already exist. Existing `AGENTS.md` files are never overwritten.
 
 When installing with `--for claude`, a `CLAUDE.md` file is also generated at the project root. This file uses Claude Code's native `@path/to/file` import syntax to reference installed skills and agents, giving Claude Code direct visibility into your installed capabilities. Like `AGENTS.md`, existing `CLAUDE.md` files are never overwritten.
+
+#### Installing from external sources
+
+The `--from` flag lets you install packages from Git repositories outside the built-in registry. The source must follow the standard `code-minions` layout with a `packages/` directory at the root.
+
+```bash
+# Install from a Git URL
+code-minions install --package developer-mentor --from https://github.com/willvelida/MinionsHub.git
+
+# Install from a bare GitHub path (https:// and .git are optional)
+code-minions install --package developer-mentor --from github.com/willvelida/MinionsHub
+
+# Install for a specific assistant
+code-minions install --package developer-mentor --from github.com/willvelida/MinionsHub --for copilot
+
+# Install multiple packages
+code-minions install --package threat-modelling,git-workflow --from github.com/willvelida/MinionsHub
+
+# Preview what would be installed
+code-minions install --package developer-mentor --from github.com/willvelida/MinionsHub --dry-run
+```
+
+You can also configure named sources so you don't have to type the full URL every time:
+
+```bash
+# Add a named source
+code-minions source add my-team --url https://github.com/my-org/agent-packages.git
+
+# Install using the source name
+code-minions install --package my-skill --from my-team
+
+# List packages from all configured sources
+code-minions list
+```
+
+The [willvelida/MinionsHub](https://github.com/willvelida/MinionsHub) repository is a public example of a compatible package source.
 
 ### Uninstalling
 

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -24,16 +24,17 @@ func newInstallCommand(content fs.FS) *cobra.Command {
 		Use:   "install",
 		Short: "Install agents and skills into your repository",
 		Long: `Install copies agent definitions and skill files from the built-in
-package registry into your repository. Files are placed relative to the
-target directory, organised into agents/ and skills/ directories.
+package registry (or an external source) into your repository. Files are
+placed relative to the target directory, organised into agents/ and
+skills/ directories.
 
 When --for is specified, files are placed in the assistant-specific
 location (e.g. .github/agents/ for GitHub Copilot, .claude/agents/ for Claude).
 
-When --from is specified, the source is recorded in the installation
-manifest for tracking purposes. Note: package downloads from external
-sources are not yet implemented (see issue #136); the package content
-is still resolved from the built-in registry.
+When --from is specified, packages are fetched from the named source or
+Git URL. The source must contain a packages/ directory following the
+standard code-minions layout. Use 'code-minions source add' to configure
+named sources, or pass a Git URL directly.
 
 An AGENTS.md routing file is created at the root of the target to help
 AI assistants discover installed agents. If AGENTS.md already exists,
@@ -50,11 +51,14 @@ preview changes without writing any files.`,
   # Install a specific package
   code-minions install --package git-workflow
 
-  # Record a named source in the manifest (content still from built-in registry; see #136)
+  # Install a package from a named source
   code-minions install --package my-skill --from my-team
 
-  # Record a Git URL as source in the manifest (content still from built-in registry; see #136)
+  # Install a package from a Git URL
   code-minions install --package my-skill --from https://github.com/org/packages.git
+
+  # Install from a bare GitHub path
+  code-minions install --package my-skill --from github.com/org/packages
 
   # Preview what would be installed
   code-minions install --dry-run
@@ -100,7 +104,7 @@ preview changes without writing any files.`,
 						"Usage: code-minions install --persona <name> --for <assistant>\n\n"+
 						"Available assistants: %s", strings.Join(assistant.List(), ", "))
 				}
-				return runPersonaInstall(cmd, content, personaFlag, forFlag, target, force, dryRun)
+				return runPersonaInstall(cmd, content, personaFlag, forFlag, fromFlag, target, force, dryRun)
 			}
 
 			mode := getOutputMode(cmd)
@@ -119,6 +123,13 @@ preview changes without writing any files.`,
 					return err
 				}
 				pathMapper = cfg.NewPathMapper()
+			}
+
+			// --- Remote source install branch ---
+			// When --from is set with --package, use registry-based resolution
+			// to download and install from the external source.
+			if fromFlag != "" && packageFlag != "" {
+				return installFromSource(cmd, content, fromFlag, packageFlag, forFlag, target, force, dryRun, mode)
 			}
 
 			// Build the list of package directories to install
@@ -685,16 +696,24 @@ func listSubDirs(content fs.FS, dir string) ([]string, error) {
 func runPersonaInstall(
 	cmd *cobra.Command,
 	content fs.FS,
-	personaName, assistantName, target string,
+	personaName, assistantName, fromFlag, target string,
 	force, dryRun bool,
 ) error {
 	mode := getOutputMode(cmd)
 
 	// --- Step 1: Resolve the persona ---
-	// Create a registry with the embedded source, then use the
-	// PersonaResolver to look up the persona and all its packages.
-	src := registry.NewEmbeddedSource(content)
-	reg := registry.NewRegistry(src)
+	// Build a registry from --from (if set) or embedded source.
+	var reg *registry.Registry
+	if fromFlag != "" {
+		var err error
+		reg, err = registry.BuildRegistryWithFrom(content, fromFlag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve source %q: %w", fromFlag, err)
+		}
+	} else {
+		src := registry.NewEmbeddedSource(content)
+		reg = registry.NewRegistry(src)
+	}
 	resolver := registry.NewPersonaResolver(reg)
 
 	resolved, err := resolver.Resolve(personaName)
@@ -866,4 +885,437 @@ func formatPersonaResult(
 	}
 
 	return nil
+}
+
+// installFromSource handles the `install --from <source> --package <name>`
+// path. When --from is set, packages are resolved through the registry
+// and downloaded via DownloadPackage, rather than read from the embedded FS.
+//
+// This mirrors the PersonaInstaller pattern: DownloadPackage returns an
+// fs.FS rooted at the package directory (agents/, skills/ at root), so
+// the Installer is used without StripPrefix.
+func installFromSource(
+	cmd *cobra.Command,
+	content fs.FS,
+	fromFlag, packageFlag, forFlag, target string,
+	force, dryRun bool,
+	mode OutputMode,
+) error {
+	// 1. Build registry scoped to --from source
+	reg, err := registry.BuildRegistryWithFrom(content, fromFlag)
+	if err != nil {
+		return fmt.Errorf("failed to resolve source %q: %w", fromFlag, err)
+	}
+
+	// 2. Parse comma-separated packages
+	packages := parsePackageNames(packageFlag)
+
+	// 3. Set up path mapper for --for
+	var pathMapper func(string) string
+	if forFlag != "" {
+		cfg, err := assistant.Get(forFlag)
+		if err != nil {
+			return err
+		}
+		pathMapper = cfg.NewPathMapper()
+	}
+
+	if dryRun && (mode == OutputNormal || mode == OutputVerbose) {
+		_, _ = color.New(color.FgYellow, color.Bold).Println("Dry run - no files will be written")
+		fmt.Println()
+	}
+
+	// 4. Resolve and download each package from the source
+	type resolvedPkg struct {
+		name    string
+		version string
+		source  registry.Source
+		pkgFS   fs.FS
+	}
+	var resolved []resolvedPkg
+
+	for _, pkgName := range packages {
+		pkg, src, err := reg.ResolvePackage(pkgName)
+		if err != nil {
+			// List available packages to help the user
+			available, listErr := reg.ListPackages()
+			if listErr == nil && len(available) > 0 {
+				var names []string
+				for _, p := range available {
+					names = append(names, p.Name)
+				}
+				return fmt.Errorf("package %q not found in source %q\n\nAvailable packages:\n  %s",
+					pkgName, fromFlag, strings.Join(names, "\n  "))
+			}
+			return fmt.Errorf("package %q not found in source %q: %w", pkgName, fromFlag, err)
+		}
+
+		pkgFS, err := src.DownloadPackage(pkgName, pkg.Version)
+		if err != nil {
+			return fmt.Errorf("failed to download package %q: %w", pkgName, err)
+		}
+
+		resolved = append(resolved, resolvedPkg{
+			name:    pkgName,
+			version: pkg.Version,
+			source:  src,
+			pkgFS:   pkgFS,
+		})
+	}
+
+	// 5. Install each resolved package
+	combinedResult := &installer.Result{}
+	perPkgCopied := make(map[string][]string)
+	instrTranslator := installer.NewInstructionTranslator(forFlag)
+
+	for _, rp := range resolved {
+		// Discover top-level directories (agents/, skills/, instructions/, etc.)
+		dirs, err := discoverTopDirs(rp.pkgFS)
+		if err != nil {
+			combinedResult.Errors = append(combinedResult.Errors,
+				fmt.Sprintf("%s: failed to discover package contents: %v", rp.name, err))
+			continue
+		}
+
+		inst := &installer.Installer{
+			Content:    rp.pkgFS,
+			Target:     target,
+			Force:      force,
+			DryRun:     dryRun,
+			PathMapper: pathMapper,
+			// No StripPrefix — DownloadPackage returns package-rooted FS
+		}
+		inst.FileTransformer = instrTranslator.TranslateContent
+
+		result, err := inst.Install(dirs)
+		if err != nil {
+			return fmt.Errorf("installation of %q failed: %w", rp.name, err)
+		}
+		combinedResult.Copied = append(combinedResult.Copied, result.Copied...)
+		combinedResult.Skipped = append(combinedResult.Skipped, result.Skipped...)
+		combinedResult.Errors = append(combinedResult.Errors, result.Errors...)
+		perPkgCopied[rp.name] = result.Copied
+	}
+
+	// 6. Create AGENTS.md if installing packages
+	if len(resolved) > 0 {
+		agentsMDPath := "AGENTS.md"
+		if pathMapper != nil {
+			agentsMDPath = pathMapper("agents/AGENTS.md")
+		}
+
+		handlerStdout := io.Writer(os.Stdout)
+		if mode == OutputJSON || mode == OutputQuiet {
+			handlerStdout = io.Discard
+		}
+		handler := &installer.AgentsMDHandler{
+			Target: target,
+			DryRun: dryRun,
+			Stdin:  os.Stdin,
+			Stdout: handlerStdout,
+		}
+
+		action, err := handler.OnInstall(agentsMDPath, []byte(installer.DefaultAgentsMDContent))
+		if err != nil {
+			combinedResult.Errors = append(combinedResult.Errors, fmt.Sprintf("AGENTS.md: %v", err))
+		} else if action == "created" {
+			combinedResult.Copied = append(combinedResult.Copied, agentsMDPath)
+		} else {
+			combinedResult.Skipped = append(combinedResult.Skipped, agentsMDPath)
+		}
+	}
+
+	// 7. Create CLAUDE.md when installing for Claude
+	if strings.EqualFold(forFlag, "claude") && len(resolved) > 0 {
+		cfg, cfgErr := assistant.Get(forFlag)
+		if cfgErr == nil && cfg.InstructionsPath != "" {
+			instrStdout := io.Writer(os.Stdout)
+			if mode == OutputJSON || mode == OutputQuiet {
+				instrStdout = io.Discard
+			}
+			instrHandler := &installer.InstructionsFileHandler{
+				Target:   target,
+				DryRun:   dryRun,
+				FileName: cfg.InstructionsPath,
+				Stdin:    os.Stdin,
+				Stdout:   instrStdout,
+			}
+			var pkgNames []string
+			for _, rp := range resolved {
+				pkgNames = append(pkgNames, rp.name)
+			}
+			instrContent := installer.BuildClaudeMDForPackages(pkgNames, cfg)
+			instrAction, instrErr := instrHandler.OnInstall([]byte(instrContent))
+			if instrErr != nil {
+				combinedResult.Errors = append(combinedResult.Errors,
+					fmt.Sprintf("%s: %v", cfg.InstructionsPath, instrErr))
+			} else if instrAction == "created" {
+				combinedResult.Copied = append(combinedResult.Copied, cfg.InstructionsPath)
+			} else {
+				combinedResult.Skipped = append(combinedResult.Skipped, cfg.InstructionsPath)
+			}
+		}
+	}
+
+	// 8. MCP server processing — use the package-rooted FS with "." as pkgDir
+	mcpResults := make(map[string]*mcp.InstallResult)
+	if forFlag != "" {
+		translator, err := mcp.NewTranslator(forFlag)
+		if err != nil {
+			combinedResult.Errors = append(combinedResult.Errors, fmt.Sprintf("MCP: %v", err))
+		} else {
+			for _, rp := range resolved {
+				// For remote packages, the FS is already package-rooted,
+				// so we use "." as the package directory.
+				mcpResult, err := mcp.Install(rp.pkgFS, ".", target, translator, force, dryRun)
+				if err != nil {
+					combinedResult.Errors = append(combinedResult.Errors, fmt.Sprintf("MCP (%s): %v", rp.name, err))
+					continue
+				}
+				if mcpResult != nil {
+					mcpResults[rp.name] = mcpResult
+				}
+			}
+		}
+	}
+
+	// 9. Record installation in manifest (skip for dry-run)
+	if !dryRun && (len(combinedResult.Copied) > 0 || len(mcpResults) > 0) {
+		// Determine the source name for manifest recording
+		sourceName := fromFlag
+		if registry.IsGitURL(fromFlag) {
+			sourceName = registry.ShortNameFromURL(fromFlag)
+		}
+
+		installManifest, err := installer.LoadManifest(target)
+		if err != nil {
+			combinedResult.Errors = append(combinedResult.Errors, fmt.Sprintf("manifest load: %v", err))
+		} else {
+			for _, rp := range resolved {
+				pkgFiles := perPkgCopied[rp.name]
+				installer.RecordInstall(installManifest, rp.name, rp.version, sourceName, forFlag, pkgFiles)
+
+				if mcpResult, ok := mcpResults[rp.name]; ok && len(mcpResult.Merge.Added) > 0 {
+					addedServers := make([]string, len(mcpResult.Merge.Added))
+					copy(addedServers, mcpResult.Merge.Added)
+					sort.Strings(addedServers)
+					if entry := installer.FindInstalled(installManifest, rp.name); entry != nil {
+						entry.MCPServers = addedServers
+					}
+				}
+			}
+			if err := installer.SaveManifest(target, installManifest); err != nil {
+				combinedResult.Errors = append(combinedResult.Errors, fmt.Sprintf("manifest: %v", err))
+			}
+		}
+	}
+
+	// 10. Update project manifest (code-minions.yml)
+	if !dryRun && packageFlag != "" {
+		manifestPath := manifest.DefaultPath(target)
+		m, err := manifest.Load(manifestPath)
+		if err != nil {
+			combinedResult.Errors = append(combinedResult.Errors,
+				fmt.Sprintf("%s load: %v", manifest.FileName, err))
+		} else {
+			if m.Name == "" {
+				absTarget, absErr := filepath.Abs(target)
+				if absErr == nil {
+					m.Name = filepath.Base(absTarget)
+				}
+			}
+			if forFlag != "" && m.Assistant == "" {
+				m.Assistant = forFlag
+			}
+			for _, rp := range resolved {
+				m.AddPackage(rp.name)
+			}
+			if saveErr := manifest.Save(manifestPath, m); saveErr != nil {
+				combinedResult.Errors = append(combinedResult.Errors,
+					fmt.Sprintf("%s: %v", manifest.FileName, saveErr))
+			} else {
+				verbosePrintf(cmd, mode, "updated %s\n", manifest.FileName)
+			}
+		}
+	}
+
+	// 11. Output results
+	return formatInstallResult(cmd, mode, combinedResult, mcpResults, dryRun)
+}
+
+// formatInstallResult handles JSON, quiet, and normal output modes for
+// the package install result. This is shared between the embedded and
+// remote install paths.
+func formatInstallResult(
+	cmd *cobra.Command,
+	mode OutputMode,
+	combinedResult *installer.Result,
+	mcpResults map[string]*mcp.InstallResult,
+	dryRun bool,
+) error {
+	// JSON output
+	if mode == OutputJSON {
+		copied := combinedResult.Copied
+		if copied == nil {
+			copied = []string{}
+		}
+		skipped := combinedResult.Skipped
+		if skipped == nil {
+			skipped = []string{}
+		}
+		errs := combinedResult.Errors
+		if errs == nil {
+			errs = []string{}
+		}
+
+		type mcpJSONEntry struct {
+			Package    string   `json:"package"`
+			ConfigPath string   `json:"config_path"`
+			Added      []string `json:"added"`
+			Skipped    []string `json:"skipped"`
+			Conflicts  []string `json:"conflicts"`
+			Warnings   []string `json:"warnings"`
+		}
+		var mcpEntries []mcpJSONEntry
+		mcpPkgNames := sortedKeys(mcpResults)
+		for _, pkgName := range mcpPkgNames {
+			mr := mcpResults[pkgName]
+			entry := mcpJSONEntry{
+				Package:    pkgName,
+				ConfigPath: mr.ConfigPath,
+				Added:      nonNil(mr.Merge.Added),
+				Skipped:    nonNil(mr.Merge.Skipped),
+				Conflicts:  nonNil(mr.Merge.Conflict),
+				Warnings:   nonNil(mr.Merge.Warnings),
+			}
+			mcpEntries = append(mcpEntries, entry)
+		}
+		if mcpEntries == nil {
+			mcpEntries = []mcpJSONEntry{}
+		}
+
+		result := struct {
+			Copied  []string       `json:"copied"`
+			Skipped []string       `json:"skipped"`
+			Errors  []string       `json:"errors"`
+			MCP     []mcpJSONEntry `json:"mcp"`
+			Summary struct {
+				Copied  int `json:"copied"`
+				Skipped int `json:"skipped"`
+				Errors  int `json:"errors"`
+			} `json:"summary"`
+		}{
+			Copied:  copied,
+			Skipped: skipped,
+			Errors:  errs,
+			MCP:     mcpEntries,
+		}
+		result.Summary.Copied = len(combinedResult.Copied)
+		result.Summary.Skipped = len(combinedResult.Skipped)
+		result.Summary.Errors = len(combinedResult.Errors)
+		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(result); err != nil {
+			return err
+		}
+		if len(combinedResult.Errors) > 0 {
+			return fmt.Errorf("installation completed with %d errors", len(combinedResult.Errors))
+		}
+		return nil
+	}
+
+	// Quiet mode
+	if mode == OutputQuiet {
+		for _, e := range combinedResult.Errors {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  error: %s\n", e)
+		}
+		if len(combinedResult.Errors) > 0 {
+			return fmt.Errorf("installation completed with %d errors", len(combinedResult.Errors))
+		}
+		return nil
+	}
+
+	// Normal / verbose output
+	green := color.New(color.FgGreen)
+	yellow := color.New(color.FgYellow)
+	red := color.New(color.FgRed)
+	bold := color.New(color.Bold)
+
+	for _, f := range combinedResult.Copied {
+		if dryRun {
+			_, _ = yellow.Printf("  would copy: %s\n", f)
+		} else {
+			_, _ = green.Printf("  copied: %s\n", f)
+		}
+	}
+	for _, f := range combinedResult.Skipped {
+		_, _ = yellow.Printf("  skipped (exists): %s\n", f)
+	}
+	for _, e := range combinedResult.Errors {
+		_, _ = red.Fprintf(os.Stderr, "  error: %s\n", e)
+	}
+
+	// MCP server results
+	if len(mcpResults) > 0 {
+		cyan := color.New(color.FgCyan)
+		fmt.Println()
+		_, _ = bold.Println("MCP servers:")
+		mcpPkgNames := sortedKeys(mcpResults)
+		for _, pkgName := range mcpPkgNames {
+			mr := mcpResults[pkgName]
+			for _, s := range mr.Merge.Added {
+				if dryRun {
+					_, _ = yellow.Printf("  would add to %s: %s (package: %s)\n", mr.ConfigPath, s, pkgName)
+				} else {
+					_, _ = cyan.Printf("  added to %s: %s (package: %s)\n", mr.ConfigPath, s, pkgName)
+				}
+			}
+			for _, s := range mr.Merge.Skipped {
+				_, _ = yellow.Printf("  skipped (identical): %s in %s\n", s, mr.ConfigPath)
+			}
+			for _, s := range mr.Merge.Conflict {
+				_, _ = yellow.Printf("  conflict: %s in %s (use --force to overwrite)\n", s, mr.ConfigPath)
+			}
+			for _, w := range mr.Merge.Warnings {
+				_, _ = yellow.Printf("  warning: %s\n", w)
+			}
+		}
+	}
+
+	// Summary
+	fmt.Println()
+	_, _ = bold.Printf("%d copied, %d skipped, %d errors\n",
+		len(combinedResult.Copied), len(combinedResult.Skipped), len(combinedResult.Errors))
+
+	if len(combinedResult.Errors) > 0 {
+		return fmt.Errorf("installation completed with %d errors", len(combinedResult.Errors))
+	}
+
+	return nil
+}
+
+// parsePackageNames splits a comma-separated package flag into trimmed names.
+func parsePackageNames(flag string) []string {
+	var names []string
+	for _, name := range strings.Split(flag, ",") {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// discoverTopDirs returns the top-level directory names in a package FS.
+// For a typical package this returns ["agents", "skills"].
+func discoverTopDirs(pkgFS fs.FS) ([]string, error) {
+	entries, err := fs.ReadDir(pkgFS, ".")
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e.Name())
+		}
+	}
+	return dirs, nil
 }

--- a/internal/cmd/integration_test.go
+++ b/internal/cmd/integration_test.go
@@ -604,3 +604,879 @@ func TestIntegration_MultipleSourcesMerge(t *testing.T) {
 		t.Errorf("expected 3 sources, got %d", len(reg.Sources()))
 	}
 }
+
+// ---------- Integration tests for install --from ----------
+
+// setupIntegrationGitRepoWithMCP creates a local Git repository with
+// a package that includes an mcp.yaml file for MCP server testing.
+func setupIntegrationGitRepoWithMCP(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	cacheDir := t.TempDir()
+	registry.SetCacheRoot(cacheDir)
+	t.Cleanup(func() { registry.SetCacheRoot("") })
+
+	dir := t.TempDir()
+	pkgDir := filepath.Join(dir, "packages", "mcp-skill")
+	if err := os.MkdirAll(filepath.Join(pkgDir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(pkgDir, "skills", "mcp-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// package.yaml
+	manifest := "name: mcp-skill\nversion: 1.0.0\ndescription: MCP test skill\n"
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "agents", "mcp-skill.agent.md"),
+		[]byte("# MCP Agent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "skills", "mcp-skill", "SKILL.md"),
+		[]byte("# MCP Skill\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// mcp.yaml
+	mcpYAML := `servers:
+  test-server:
+    transport: stdio
+    command: node
+    args: ["server.js"]
+`
+	if err := os.WriteFile(filepath.Join(pkgDir, "mcp.yaml"), []byte(mcpYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	return dir
+}
+
+// TestIntegration_InstallFromGitURL tests installing a package from
+// a local Git repository URL using --from.
+func TestIntegration_InstallFromGitURL(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --from failed: %v", err)
+	}
+
+	// Verify agent file was installed
+	agentFile := filepath.Join(target, "agents", "external-skill.agent.md")
+	if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+		t.Errorf("expected agent file at %s", agentFile)
+	}
+
+	// Verify skill file was installed
+	skillFile := filepath.Join(target, "skills", "external-skill", "SKILL.md")
+	if _, err := os.Stat(skillFile); os.IsNotExist(err) {
+		t.Errorf("expected skill file at %s", skillFile)
+	}
+
+	// Verify AGENTS.md was created
+	agentsMD := filepath.Join(target, "AGENTS.md")
+	if _, err := os.Stat(agentsMD); os.IsNotExist(err) {
+		t.Errorf("expected AGENTS.md at %s", agentsMD)
+	}
+}
+
+// TestIntegration_InstallFromGitURLForCopilot tests that --from with
+// --for copilot places files in the correct assistant directory.
+func TestIntegration_InstallFromGitURLForCopilot(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--for", "copilot",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --from --for copilot failed: %v", err)
+	}
+
+	// Agent should be in .github/agents/ (Copilot path mapping)
+	copilotAgent := filepath.Join(target, ".github", "agents", "external-skill.agent.md")
+	if _, err := os.Stat(copilotAgent); os.IsNotExist(err) {
+		t.Errorf("expected agent at Copilot path: %s", copilotAgent)
+	}
+
+	// Skill should remain at skills/ (Copilot doesn't remap skills)
+	skillFile := filepath.Join(target, "skills", "external-skill", "SKILL.md")
+	if _, err := os.Stat(skillFile); os.IsNotExist(err) {
+		t.Errorf("expected skill at default path: %s", skillFile)
+	}
+}
+
+// TestIntegration_InstallFromMultiplePackages tests installing multiple
+// comma-separated packages from an external source.
+func TestIntegration_InstallFromMultiplePackages(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	// Create a repo with two packages
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	cacheDir := t.TempDir()
+	registry.SetCacheRoot(cacheDir)
+	t.Cleanup(func() { registry.SetCacheRoot("") })
+
+	dir := t.TempDir()
+	for _, pkgName := range []string{"skill-a", "skill-b"} {
+		pkgDir := filepath.Join(dir, "packages", pkgName)
+		if err := os.MkdirAll(filepath.Join(pkgDir, "agents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.yaml"),
+			[]byte("name: "+pkgName+"\nversion: 1.0.0\ndescription: "+pkgName+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "agents", pkgName+".agent.md"),
+			[]byte("# "+pkgName+" Agent\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", err, out)
+		}
+	}
+
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "skill-a,skill-b",
+		"--from", dir,
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	// Both packages should be installed
+	for _, pkgName := range []string{"skill-a", "skill-b"} {
+		agentFile := filepath.Join(target, "agents", pkgName+".agent.md")
+		if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+			t.Errorf("expected %s agent file at %s", pkgName, agentFile)
+		}
+	}
+}
+
+// TestIntegration_InstallFromDryRun tests that --dry-run with --from
+// does not write any files.
+func TestIntegration_InstallFromDryRun(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+		"--dry-run",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --dry-run failed: %v", err)
+	}
+
+	// No files should be written
+	agentFile := filepath.Join(target, "agents", "external-skill.agent.md")
+	if _, err := os.Stat(agentFile); !os.IsNotExist(err) {
+		t.Errorf("dry-run should not create files, but found: %s", agentFile)
+	}
+}
+
+// TestIntegration_InstallFromForce tests that --force overwrites
+// existing files when installing from an external source.
+func TestIntegration_InstallFromForce(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	// Pre-create the agent file with different content
+	agentDir := filepath.Join(target, "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentFile := filepath.Join(agentDir, "external-skill.agent.md")
+	if err := os.WriteFile(agentFile, []byte("old content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install without --force: should skip
+	cmd1 := newInstallCommand(fstest.MapFS{})
+	cmd1.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+	})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first install failed: %v", err)
+	}
+
+	// Content should still be old
+	data, _ := os.ReadFile(agentFile)
+	if string(data) != "old content" {
+		t.Error("expected file to be skipped (old content preserved)")
+	}
+
+	// Install with --force: should overwrite
+	cmd2 := newInstallCommand(fstest.MapFS{})
+	cmd2.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+		"--force",
+	})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("force install failed: %v", err)
+	}
+
+	// Content should now be from external source
+	data, _ = os.ReadFile(agentFile)
+	if string(data) == "old content" {
+		t.Error("expected --force to overwrite file content")
+	}
+}
+
+// TestIntegration_InstallFromPackageNotFound tests the error when a
+// package doesn't exist in the external source.
+func TestIntegration_InstallFromPackageNotFound(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "nonexistent-package",
+		"--from", repoDir,
+		"--target", t.TempDir(),
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent package")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "nonexistent-package") {
+		t.Errorf("error should mention the package name, got: %s", errMsg)
+	}
+	// Should list available packages
+	if !strings.Contains(errMsg, "external-skill") {
+		t.Errorf("error should list available packages, got: %s", errMsg)
+	}
+}
+
+// TestIntegration_InstallFromRecordsManifest tests that the install
+// manifest correctly records the source name for remote installs.
+func TestIntegration_InstallFromRecordsManifest(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	// Read the install manifest
+	manifestPath := filepath.Join(target, ".code-minions", "installed.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("failed to read manifest: %v", err)
+	}
+
+	// Parse and verify
+	var m struct {
+		Packages []struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			Source  string `json:"source"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("failed to parse manifest: %v", err)
+	}
+
+	if len(m.Packages) != 1 {
+		t.Fatalf("expected 1 package in manifest, got %d", len(m.Packages))
+	}
+
+	pkg := m.Packages[0]
+	if pkg.Name != "external-skill" {
+		t.Errorf("manifest package name = %q, want external-skill", pkg.Name)
+	}
+	if pkg.Version != "2.0.0" {
+		t.Errorf("manifest version = %q, want 2.0.0", pkg.Version)
+	}
+	// Source should NOT be "embedded"
+	if pkg.Source == "embedded" || pkg.Source == "" {
+		t.Errorf("manifest source should not be empty or 'embedded', got %q", pkg.Source)
+	}
+}
+
+// TestIntegration_InstallFromUpdatesProjectManifest tests that the
+// project manifest (code-minions.yml) is updated after remote install.
+func TestIntegration_InstallFromUpdatesProjectManifest(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	// Read code-minions.yml
+	manifestPath := filepath.Join(target, "code-minions.yml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("failed to read project manifest: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "external-skill") {
+		t.Errorf("project manifest should contain 'external-skill', got:\n%s", content)
+	}
+}
+
+// TestIntegration_InstallFromJSONOutput tests JSON output mode with
+// remote package installation.
+func TestIntegration_InstallFromJSONOutput(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	// Use root command so the persistent --json flag is available
+	cmd := NewRootCommand(fstest.MapFS{})
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"install",
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+		"--json",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --json failed: %v", err)
+	}
+
+	// Parse JSON output
+	var result struct {
+		Copied  []string `json:"copied"`
+		Skipped []string `json:"skipped"`
+		Errors  []string `json:"errors"`
+		Summary struct {
+			Copied  int `json:"copied"`
+			Skipped int `json:"skipped"`
+			Errors  int `json:"errors"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(buf.String()), &result); err != nil {
+		t.Fatalf("failed to parse JSON output: %v\nraw: %s", err, buf.String())
+	}
+
+	if result.Summary.Copied == 0 {
+		t.Error("expected at least one copied file")
+	}
+	if result.Summary.Errors != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", result.Summary.Errors, result.Errors)
+	}
+}
+
+// TestIntegration_InstallFromMCPProcessing tests that MCP servers in
+// remote packages are processed correctly.
+func TestIntegration_InstallFromMCPProcessing(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepoWithMCP(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "mcp-skill",
+		"--from", repoDir,
+		"--for", "copilot",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install with MCP failed: %v", err)
+	}
+
+	// Agent file should be installed
+	agentFile := filepath.Join(target, ".github", "agents", "mcp-skill.agent.md")
+	if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+		t.Errorf("expected agent file at %s", agentFile)
+	}
+
+	// MCP config should be written
+	mcpConfig := filepath.Join(target, ".vscode", "mcp.json")
+	if _, err := os.Stat(mcpConfig); os.IsNotExist(err) {
+		t.Errorf("expected MCP config at %s", mcpConfig)
+	}
+
+	// MCP config should contain the test-server
+	if data, err := os.ReadFile(mcpConfig); err == nil {
+		if !strings.Contains(string(data), "test-server") {
+			t.Errorf("MCP config should contain 'test-server', got:\n%s", string(data))
+		}
+	}
+}
+
+// TestIntegration_InstallFromForClaude tests that --from with
+// --for claude places files in Claude directories and generates CLAUDE.md.
+func TestIntegration_InstallFromForClaude(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--for", "claude",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --from --for claude failed: %v", err)
+	}
+
+	// Agent should be in .claude/agents/ (Claude path mapping)
+	claudeAgent := filepath.Join(target, ".claude", "agents", "external-skill.agent.md")
+	if _, err := os.Stat(claudeAgent); os.IsNotExist(err) {
+		t.Errorf("expected agent at Claude path: %s", claudeAgent)
+	}
+
+	// Skill should be in .claude/skills/ (Claude remaps skills)
+	skillFile := filepath.Join(target, ".claude", "skills", "external-skill", "SKILL.md")
+	if _, err := os.Stat(skillFile); os.IsNotExist(err) {
+		t.Errorf("expected skill at Claude path: %s", skillFile)
+	}
+
+	// CLAUDE.md should be generated
+	claudeMD := filepath.Join(target, "CLAUDE.md")
+	if _, err := os.Stat(claudeMD); os.IsNotExist(err) {
+		t.Errorf("expected CLAUDE.md at %s", claudeMD)
+	} else {
+		data, _ := os.ReadFile(claudeMD)
+		content := string(data)
+		if !strings.Contains(content, "external-skill") {
+			t.Errorf("CLAUDE.md should reference 'external-skill', got:\n%s", content)
+		}
+	}
+}
+
+// TestIntegration_InstallFromUnreachableSource tests error handling when
+// the --from source is an unreachable URL.
+func TestIntegration_InstallFromUnreachableSource(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	// Redirect cache to avoid contamination
+	cacheDir := t.TempDir()
+	registry.SetCacheRoot(cacheDir)
+	t.Cleanup(func() { registry.SetCacheRoot("") })
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "some-pkg",
+		"--from", "https://github.com/nonexistent-org-12345/nonexistent-repo-67890.git",
+		"--target", t.TempDir(),
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unreachable source")
+	}
+}
+
+// TestIntegration_InstallFromWithoutPackage tests that --from without
+// --package produces a clear error message.
+func TestIntegration_InstallFromWithoutPackage(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--from", "some-source",
+		"--target", t.TempDir(),
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --from is used without --package")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "--from requires --package") {
+		t.Errorf("error should mention '--from requires --package', got: %s", errMsg)
+	}
+}
+
+// TestIntegration_InstallFromNamedSource tests the full lifecycle of
+// configuring a named source and then installing from it.
+func TestIntegration_InstallFromNamedSource(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+
+	// Build a registry with a named source config
+	cfg := &registry.Config{
+		Sources: []registry.SourceConfig{
+			{Name: "team-source", Type: "git", URL: repoDir},
+		},
+	}
+
+	// Use BuildRegistryWithFromAndConfig to resolve the named source
+	reg, err := registry.BuildRegistryWithFromAndConfig(fstest.MapFS{}, "team-source", cfg)
+	if err != nil {
+		t.Fatalf("failed to resolve named source: %v", err)
+	}
+
+	// Verify the registry can find the package
+	pkg, src, err := reg.ResolvePackage("external-skill")
+	if err != nil {
+		t.Fatalf("failed to resolve package: %v", err)
+	}
+	if pkg.Name != "external-skill" {
+		t.Errorf("package name = %q, want external-skill", pkg.Name)
+	}
+	if src.Name() != "team-source" {
+		t.Errorf("source name = %q, want team-source", src.Name())
+	}
+
+	// Download and verify the package
+	pkgFS, err := src.DownloadPackage("external-skill", pkg.Version)
+	if err != nil {
+		t.Fatalf("failed to download package: %v", err)
+	}
+
+	// Verify the package FS contains expected files
+	agentFile, err := pkgFS.Open("agents/external-skill.agent.md")
+	if err != nil {
+		t.Fatalf("package FS missing agent file: %v", err)
+	}
+	_ = agentFile.Close()
+
+	// Now do a full install using the install command directly
+	// This tests the complete path through installFromSource
+	target2 := t.TempDir()
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target2,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --from named source failed: %v", err)
+	}
+
+	installed := filepath.Join(target2, "agents", "external-skill.agent.md")
+	if _, err := os.Stat(installed); os.IsNotExist(err) {
+		t.Errorf("expected installed agent at %s", installed)
+	}
+}
+
+// setupIntegrationGitRepoWithPersona creates a local Git repository
+// that includes both packages and a persona for testing persona --from.
+func setupIntegrationGitRepoWithPersona(t *testing.T) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	cacheDir := t.TempDir()
+	registry.SetCacheRoot(cacheDir)
+	t.Cleanup(func() { registry.SetCacheRoot("") })
+
+	dir := t.TempDir()
+
+	// Create two packages
+	for _, pkgName := range []string{"pkg-alpha", "pkg-beta"} {
+		pkgDir := filepath.Join(dir, "packages", pkgName)
+		if err := os.MkdirAll(filepath.Join(pkgDir, "agents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(pkgDir, "skills", pkgName), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.yaml"),
+			[]byte("name: "+pkgName+"\nversion: 1.0.0\ndescription: "+pkgName+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "agents", pkgName+".agent.md"),
+			[]byte("# "+pkgName+" Agent\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "skills", pkgName, "SKILL.md"),
+			[]byte("# "+pkgName+" Skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a persona
+	personaDir := filepath.Join(dir, "personas", "test-remote-persona")
+	if err := os.MkdirAll(personaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	personaYAML := `name: test-remote-persona
+description: A test persona from a remote source
+packages:
+  - name: pkg-alpha
+  - name: pkg-beta
+`
+	if err := os.WriteFile(filepath.Join(personaDir, "persona.yaml"), []byte(personaYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	return dir
+}
+
+// TestIntegration_PersonaInstallWithFrom tests installing a persona
+// from an external source using --from.
+func TestIntegration_PersonaInstallWithFrom(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepoWithPersona(t)
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--persona", "test-remote-persona",
+		"--from", repoDir,
+		"--for", "copilot",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("persona install --from failed: %v", err)
+	}
+
+	// Both packages from the persona should be installed
+	for _, pkgName := range []string{"pkg-alpha", "pkg-beta"} {
+		agentFile := filepath.Join(target, ".github", "agents", pkgName+".agent.md")
+		if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+			t.Errorf("expected persona package %s agent at %s", pkgName, agentFile)
+		}
+	}
+}
+
+// TestIntegration_InstallFromMinionsHub tests installing from the real
+// MinionsHub repository. This test requires network access and is
+// skipped when the INTEGRATION environment variable is not set.
+func TestIntegration_InstallFromMinionsHub(t *testing.T) {
+	if os.Getenv("INTEGRATION") == "" {
+		t.Skip("skipping network integration test; set INTEGRATION=1 to run")
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	cacheDir := t.TempDir()
+	registry.SetCacheRoot(cacheDir)
+	t.Cleanup(func() { registry.SetCacheRoot("") })
+
+	target := t.TempDir()
+
+	cmd := newInstallCommand(fstest.MapFS{})
+	cmd.SetArgs([]string{
+		"--package", "developer-mentor",
+		"--from", "github.com/willvelida/MinionsHub",
+		"--for", "copilot",
+		"--target", target,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("MinionsHub install failed: %v", err)
+	}
+
+	// Verify at least the agent file is present
+	agentFile := filepath.Join(target, ".github", "agents", "developer-mentor.agent.md")
+	if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+		t.Errorf("expected developer-mentor agent at %s", agentFile)
+	}
+}
+
+// TestIntegration_InstallFromQuietMode tests that --quiet with --from
+// suppresses normal output but still reports errors.
+func TestIntegration_InstallFromQuietMode(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	// Use root command for the persistent --quiet flag
+	cmd := NewRootCommand(fstest.MapFS{})
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"install",
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+		"--quiet",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --quiet failed: %v", err)
+	}
+
+	// Quiet mode should produce no stdout
+	if stdout.String() != "" {
+		t.Errorf("quiet mode should produce no stdout, got:\n%s", stdout.String())
+	}
+
+	// Files should still be installed
+	agentFile := filepath.Join(target, "agents", "external-skill.agent.md")
+	if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+		t.Errorf("expected agent file at %s even in quiet mode", agentFile)
+	}
+}
+
+// TestIntegration_InstallFromVerboseMode tests that --verbose with --from
+// produces additional output.
+func TestIntegration_InstallFromVerboseMode(t *testing.T) {
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = false })
+
+	repoDir := setupIntegrationGitRepo(t)
+	target := t.TempDir()
+
+	// Use root command for the persistent --verbose flag
+	cmd := NewRootCommand(fstest.MapFS{})
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{
+		"install",
+		"--package", "external-skill",
+		"--from", repoDir,
+		"--target", target,
+		"--verbose",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("install --verbose failed: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verbose mode should include verbose-specific output like "updated code-minions.yml"
+	// Note: "copied" messages go through color.Printf (os.Stdout) not cmd.OutOrStdout(),
+	// so we check for the verbose-specific output that goes through verbosePrintf.
+	if !strings.Contains(output, "updated code-minions.yml") {
+		t.Errorf("verbose output should contain 'updated code-minions.yml', got:\n%s", output)
+	}
+
+	// Files should be installed
+	agentFile := filepath.Join(target, "agents", "external-skill.agent.md")
+	if _, err := os.Stat(agentFile); os.IsNotExist(err) {
+		t.Errorf("expected agent file at %s", agentFile)
+	}
+}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -46,7 +46,7 @@ AGENTS.md is not modified during updates.`,
 						"Usage: code-minions update --persona <name> --for <assistant>")
 				}
 				// Re-install with force=true is the update.
-				return runPersonaInstall(cmd, content, personaFlag, forFlag, target, true, dryRun)
+				return runPersonaInstall(cmd, content, personaFlag, forFlag, "", target, true, dryRun)
 			}
 
 			// If --for is set, look up the assistant config and build a path mapper

--- a/internal/registry/builder.go
+++ b/internal/registry/builder.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"os"
+	"path/filepath"
 )
 
 // BuildRegistry constructs a Registry from the global source config
@@ -137,6 +139,16 @@ func BuildRegistryWithFromAndConfig(embeddedContent fs.FS, from string, cfg *Con
 		return NewRegistry(src), nil
 	}
 
+	// Try as a local directory path (e.g. a local clone of a package repo)
+	if dirExists(from) {
+		// Verify it has a packages/ directory
+		if !dirExists(filepath.Join(from, "packages")) {
+			return nil, fmt.Errorf("local directory %q does not contain a packages/ directory", from)
+		}
+		src := NewEmbeddedSourceWithName(os.DirFS(from), "local")
+		return NewRegistry(src), nil
+	}
+
 	// Neither a named source nor a URL
 	return nil, fmt.Errorf("source %q not found. Run 'code-minions source list' to see configured sources, or provide a Git URL", from)
 }
@@ -164,6 +176,14 @@ func ResolveFrom(from string, cfg *Config) (Source, error) {
 	// Git URL
 	if IsGitURL(from) {
 		return NewGitSourceFromURL(from)
+	}
+
+	// Local directory path
+	if dirExists(from) {
+		if !dirExists(filepath.Join(from, "packages")) {
+			return nil, fmt.Errorf("local directory %q does not contain a packages/ directory", from)
+		}
+		return NewEmbeddedSourceWithName(os.DirFS(from), "local"), nil
 	}
 
 	return nil, fmt.Errorf("source %q not found. Run 'code-minions source list' to see configured sources, or provide a Git URL", from)

--- a/internal/registry/embedded.go
+++ b/internal/registry/embedded.go
@@ -15,15 +15,23 @@ import (
 // built-in packages shipped with the CLI binary.
 type EmbeddedSource struct {
 	content fs.FS
+	name    string
 }
 
 // NewEmbeddedSource creates a Source backed by an embedded filesystem.
 // The filesystem must contain packages under a "packages/" directory.
 func NewEmbeddedSource(content fs.FS) *EmbeddedSource {
-	return &EmbeddedSource{content: content}
+	return &EmbeddedSource{content: content, name: "embedded"}
 }
 
-func (s *EmbeddedSource) Name() string { return "embedded" }
+// NewEmbeddedSourceWithName creates a Source backed by an embedded
+// filesystem with a custom name. This is used for local directory
+// sources that behave like embedded sources but need a distinct name.
+func NewEmbeddedSourceWithName(content fs.FS, name string) *EmbeddedSource {
+	return &EmbeddedSource{content: content, name: name}
+}
+
+func (s *EmbeddedSource) Name() string { return s.name }
 func (s *EmbeddedSource) Type() string { return "embedded" }
 
 // ListPackages returns all packages found under packages/ in the


### PR DESCRIPTION
## Summary

Completes Phases 4-5 of the external package sources design (issue #83), making `install --from` actually fetch and install package content from external Git repositories.

Closes #97

## Changes

### Core implementation
- Wire `--from` into install `RunE` to call `installFromSource`
- Add `installFromSource`: registry resolution, `DownloadPackage`, `Installer` with package-rooted FS, AGENTS.md/CLAUDE.md generation, MCP processing, manifest recording
- Update `runPersonaInstall` to accept and use `--from` flag
- Add local directory fallback in registry builder (`BuildRegistryWithFrom`)
- Add `NewEmbeddedSourceWithName` for custom source names on local directory sources

### Documentation
- Update install command help text and examples (remove \"not yet implemented\" caveat)
- Add `--from` flag to Install flags table in README
- Add \"Installing from external sources\" section to README with examples

### Tests (18 scenarios)
- E.1: Install single package from Git URL
- E.2: Install multiple packages from Git URL
- E.3: Install with `--for copilot` from Git source
- E.4: Install with `--for claude` (CLAUDE.md generation)
- E.5: `--dry-run` from Git source
- E.6: `--force` overwrites existing files
- E.7: Package not found error with available package listing
- E.8: Unreachable source URL error handling
- E.9: `--from` without `--package` validation
- E.10: Install manifest records source name
- E.11: Project manifest (code-minions.yml) updated
- E.12: MCP processing from remote package
- E.13: Named source install (registry API + command)
- E.14: Persona install with `--from`
- E.15: MinionsHub network test (gated by INTEGRATION=1)
- E.16: JSON output mode
- E.17: Quiet output mode
- E.18: Verbose output mode

## Files changed

| File | Change |
|------|--------|
| `internal/cmd/install.go` | Core `installFromSource` function, `formatInstallResult`, helpers; updated help text |
| `internal/cmd/update.go` | Fixed `runPersonaInstall` call site for new signature |
| `internal/cmd/integration_test.go` | 8 new test functions + `setupIntegrationGitRepoWithMCP/Persona` helpers |
| `internal/registry/builder.go` | Local directory fallback in `BuildRegistryWithFrom` and `ResolveFrom` |
| `internal/registry/embedded.go` | `NewEmbeddedSourceWithName` constructor, configurable `name` field |
| `README.md` | `--from` flag docs, external sources section |

## Testing

- All existing tests pass (backward compatibility verified)
- `go test ./...` clean across all 8 packages
- Manually tested end-to-end against `willvelida/MinionsHub`
